### PR TITLE
test: test coverage for schema_utils has been increased to 64%.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,6 @@
 [alias]
+
+coverage = ["tarpaulin"]
 run_clippy = [
     "clippy",
     "--features",

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@
 settings.json
 
 
+
 # test artifacts
 /coverage
+.coverage
 *.lcov
 *.profraw

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -1223,5 +1223,9 @@ mod tests {
         );
         let result = detect_message_type(&json!(message));
         assert!(matches!(result, MessageTypes::Error));
+
+        // default
+        let result = detect_message_type(&json!({}));
+        assert!(matches!(result, MessageTypes::Request));
     }
 }

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,0 +1,13 @@
+[version_2024_11_05]
+no-default-features = true
+features = "2024_11_05 schema_utils"
+# release = true
+
+[version_draft]
+no-default-features = true
+features = "draft schema_utils"
+# release = true
+
+[report]
+output-dir = "./.coverage"
+out = ["Html", "Xml"]

--- a/tests/common/sample_mcp_messages.json
+++ b/tests/common/sample_mcp_messages.json
@@ -57,7 +57,7 @@
     "req_tools_call_4": {"jsonrpc":"2.0","id":18,"method":"tools/call","params":{"_meta":{"progressToken":3},"name":"sampleLLM","arguments":{"a":15,"b":21,"prompt":"my prompt","maxTokens":5}}},
     /* ServerRequest::CreateMessageRequest */
     "req_sampling_create_message_2": {"method":"sampling/createMessage","params":{"messages":[{"role":"user","content":{"type":"text","text":"Resource sampleLLM context: my prompt"}}],"systemPrompt":"You are a helpful test server.","maxTokens":5,"temperature":0.7,"includeContext":"thisServer"},"jsonrpc":"2.0","id":1},
-    /* ServerRequest::CreateMessageRequest  */
+    /* ClientResult::CreateMessageResult  */
     "res_sampling_create_message_2": {"jsonrpc":"2.0","id":1,"result":{"model":"stub-model","stopReason":"endTurn","role":"assistant","content":{"type":"text","text":"This is a stub response."}}},
     /* ServerResult::CallToolResult */
     "res_tools_call_4": {"result":{"content":[{"type":"text","text":"LLM sampling result: This is a stub response."}]},"jsonrpc":"2.0","id":18},

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -2,10 +2,8 @@
 pub mod common;
 
 mod test_deserialize {
-    use rust_mcp_schema::{
-        schema_utils::*, ClientNotification, ClientRequest, RequestId, ServerRequest, ServerResult, JSONRPC_VERSION,
-        LATEST_PROTOCOL_VERSION,
-    };
+    use rust_mcp_schema::schema_utils::*;
+    use rust_mcp_schema::*;
 
     use super::common::get_message;
 
@@ -126,6 +124,16 @@ mod test_deserialize {
         ));
     }
 
+    /* ---------------------- CLIENT RESPONSES ---------------------- */
+    #[test]
+    fn test_list_tools_result() {
+        let message = get_message("res_sampling_create_message_2");
+        assert!(matches!(message, ClientMessage::Response(client_message)
+                if matches!(&client_message.result, ResultFromClient::ClientResult(client_result)
+                        if matches!( client_result, ClientResult::CreateMessageResult(_))
+                )
+        ));
+    }
     /* ---------------------- SERVER RESPONSES ---------------------- */
 
     #[test]


### PR DESCRIPTION
### 📌 Summary
Added more unit tests for the schema_utils, increasing the test coverage to 64%

### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Added a cargo alias for test coverage : `cargo coverage`
- Added `tarpaulin.toml` to produce test coverage for all versions of the schema (latest , draft)
- Added more test cases to improve the test coverage of the schema_utils

### 🛠️ Testing Steps
1- run `cargo coverage`
2- open `.coverage/tarpaulin-report.html` after it is generated


