### PR TITLE
fix: generated schema and schema_utils with new test case

### DIFF
--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 3d4877e69cbc9921e1b511a90cdf17d42483036b
-/// Generated at : 2025-02-09 16:55:01
+/// Generated at : 2025-02-09 20:40:09
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -1278,5 +1278,9 @@ mod tests {
         );
         let result = detect_message_type(&json!(message));
         assert!(matches!(result, MessageTypes::Error));
+
+        // default
+        let result = detect_message_type(&json!({}));
+        assert!(matches!(result, MessageTypes::Request));
     }
 }

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 3d4877e69cbc9921e1b511a90cdf17d42483036b
-/// Generated at : 2025-02-09 16:55:01
+/// Generated at : 2025-02-09 20:40:10
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -1267,5 +1267,9 @@ mod tests {
         );
         let result = detect_message_type(&json!(message));
         assert!(matches!(result, MessageTypes::Error));
+
+        // default
+        let result = detect_message_type(&json!({}));
+        assert!(matches!(result, MessageTypes::Request));
     }
 }


### PR DESCRIPTION
### 📌 Summary
<!-- Provide a concise description of your changes. What problem does this PR solve? -->
Generated `mcp_schema.rs` and `schema_utils.rs` once again, added back a test case that was removed accidentally 


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Generated mcp_schema.rs and schema_utils.rs.
- Added back the unit test for testing the default case in the detect_message_type() function
