### PR TITLE
feat: enhance `schema_utils` and `mcp_schema`

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ fn handle_message(message_payload: &str) -> std::result::Result<(), AppError> {
     // Check it's a Request type of message
     if let JsonrpcMessage::Request(client_message) = message {
 
-        // Check method to detect it it a "initialize" request
+        // Check method to detect is a "initialize" request
         if client_message.method == "initialize" {
 
             // Now that we can handle the message, we simply print out the details.

--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -5,8 +5,8 @@
 /// modify or extend the implementations as needed, but please do so at your own risk.
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
-/// Hash : 3d4877e69cbc9921e1b511a90cdf17d42483036b
-/// Generated at : 2025-02-09 20:40:09
+/// Hash : 55c983fd85fafa458d31f729e433c60e95932178
+/// Generated at : 2025-02-11 20:13:30
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version
@@ -4541,6 +4541,14 @@ pub struct Result {
     pub meta: ::std::option::Option<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     #[serde(flatten, default, skip_serializing_if = "::std::option::Option::is_none")]
     pub extra: ::std::option::Option<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+}
+impl ::std::default::Default for Result {
+    fn default() -> Self {
+        Self {
+            meta: Default::default(),
+            extra: Default::default(),
+        }
+    }
 }
 ///The sender or recipient of messages and data in a conversation.
 ///

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -77,6 +77,17 @@ impl ClientJsonrpcRequest {
     }
 }
 
+/// Formats the ClientJsonrpcRequest as a JSON string.
+impl Display for ClientJsonrpcRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
+    }
+}
+
 //*************************//
 //** Request From Client **//
 //*************************//
@@ -150,6 +161,17 @@ impl ClientJsonrpcNotification {
     }
 }
 
+/// Formats the ClientJsonrpcNotification as a JSON string.
+impl Display for ClientJsonrpcNotification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
+    }
+}
+
 //*******************************//
 //**  NotificationFromClient   **//
 //*******************************//
@@ -207,6 +229,17 @@ impl ClientJsonrpcResponse {
             jsonrpc: JSONRPC_VERSION.to_string(),
             result,
         }
+    }
+}
+
+/// Formats the ClientJsonrpcResponse as a JSON string.
+impl Display for ClientJsonrpcResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
     }
 }
 
@@ -331,6 +364,16 @@ impl ServerJsonrpcRequest {
     }
 }
 
+/// Formats the ServerJsonrpcRequest as a JSON string.
+impl Display for ServerJsonrpcRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
+    }
+}
 //*************************//
 //** Request From Server **//
 //*************************//
@@ -404,6 +447,16 @@ impl ServerJsonrpcNotification {
     }
 }
 
+/// Formats the ServerJsonrpcNotification as a JSON string.
+impl Display for ServerJsonrpcNotification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
+    }
+}
 //*******************************//
 //**  NotificationFromServer   **//
 //*******************************//
@@ -464,6 +517,17 @@ impl ServerJsonrpcResponse {
     }
 }
 
+/// Formats the ServerJsonrpcResponse as a JSON string.
+impl Display for ServerJsonrpcResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
+    }
+}
+
 //*******************************//
 //**      ResultFromServer     **//
 //*******************************//
@@ -508,6 +572,21 @@ impl<'de> serde::Deserialize<'de> for ResultFromServer {
             }
             Err(_) => Ok(Self::CustomResult(raw_value)),
         }
+    }
+}
+
+//***************************//
+//** impl for JsonrpcError **//
+//***************************//
+
+/// Formats the ServerJsonrpcResponse as a JSON string.
+impl Display for JsonrpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
     }
 }
 

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -5,8 +5,8 @@
 /// modify or extend the implementations as needed, but please do so at your own risk.
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
-/// Hash : 3d4877e69cbc9921e1b511a90cdf17d42483036b
-/// Generated at : 2025-02-09 20:40:10
+/// Hash : 55c983fd85fafa458d31f729e433c60e95932178
+/// Generated at : 2025-02-11 20:13:30
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version
@@ -4672,6 +4672,14 @@ pub struct Result {
     pub meta: ::std::option::Option<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     #[serde(flatten, default, skip_serializing_if = "::std::option::Option::is_none")]
     pub extra: ::std::option::Option<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+}
+impl ::std::default::Default for Result {
+    fn default() -> Self {
+        Self {
+            meta: Default::default(),
+            extra: Default::default(),
+        }
+    }
 }
 ///The sender or recipient of messages and data in a conversation.
 ///

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -77,6 +77,17 @@ impl ClientJsonrpcRequest {
     }
 }
 
+/// Formats the ClientJsonrpcRequest as a JSON string.
+impl Display for ClientJsonrpcRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
+    }
+}
+
 //*************************//
 //** Request From Client **//
 //*************************//
@@ -150,6 +161,17 @@ impl ClientJsonrpcNotification {
     }
 }
 
+/// Formats the ClientJsonrpcNotification as a JSON string.
+impl Display for ClientJsonrpcNotification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
+    }
+}
+
 //*******************************//
 //**  NotificationFromClient   **//
 //*******************************//
@@ -207,6 +229,17 @@ impl ClientJsonrpcResponse {
             jsonrpc: JSONRPC_VERSION.to_string(),
             result,
         }
+    }
+}
+
+/// Formats the ClientJsonrpcResponse as a JSON string.
+impl Display for ClientJsonrpcResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
     }
 }
 
@@ -331,6 +364,16 @@ impl ServerJsonrpcRequest {
     }
 }
 
+/// Formats the ServerJsonrpcRequest as a JSON string.
+impl Display for ServerJsonrpcRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
+    }
+}
 //*************************//
 //** Request From Server **//
 //*************************//
@@ -404,6 +447,16 @@ impl ServerJsonrpcNotification {
     }
 }
 
+/// Formats the ServerJsonrpcNotification as a JSON string.
+impl Display for ServerJsonrpcNotification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
+    }
+}
 //*******************************//
 //**  NotificationFromServer   **//
 //*******************************//
@@ -464,6 +517,17 @@ impl ServerJsonrpcResponse {
     }
 }
 
+/// Formats the ServerJsonrpcResponse as a JSON string.
+impl Display for ServerJsonrpcResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
+    }
+}
+
 //*******************************//
 //**      ResultFromServer     **//
 //*******************************//
@@ -508,6 +572,21 @@ impl<'de> serde::Deserialize<'de> for ResultFromServer {
             }
             Err(_) => Ok(Self::CustomResult(raw_value)),
         }
+    }
+}
+
+//***************************//
+//** impl for JsonrpcError **//
+//***************************//
+
+/// Formats the ServerJsonrpcResponse as a JSON string.
+impl Display for JsonrpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(self).unwrap_or_else(|err| format!("Serialization error: {}", err))
+        )
     }
 }
 


### PR DESCRIPTION
### 📌 Summary
Improved both `mcp_schema` and `schema-utils` by implementing new Traits

### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Implemented the Display trait for the Result type in mcp_schema to simplify instantiation.
- Implemented `Display` trait for `ClientMessage` and `ServerMessage` variants of the `schema_utils
