### PR TITLE
chore: add Doctests to the test script

### DIFF
--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -12,6 +12,9 @@ COMMON_FEATURES_STR="${COMMON_FEATURES[*]}"
 for FEATURE in "${SCHEMA_VERSION_FEATURES[@]}"; do
     echo "🚀 Running tests with: --features \"$COMMON_FEATURES_STR $FEATURE\""
     cargo nextest run --no-default-features --features "$COMMON_FEATURES_STR $FEATURE"
+    echo
+    echo "🚀 Running documentation tests with: --features \"$COMMON_FEATURES_STR $FEATURE\""
+    cargo test --doc --no-default-features --features "$COMMON_FEATURES_STR $FEATURE"
 
     # stop on failure
     if [ $? -ne 0 ]; then


### PR DESCRIPTION
### 📌 Summary
<!-- Provide a concise description of your changes. What problem does this PR solve? -->
Added `cargo test --doc` to run Doctests, as Doctests are currently not supported in by nextest-rs.

### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Added Doctest to the test script [scripts/run_test.sh](https://github.com/rust-mcp-stack/rust-mcp-schema/compare/chore/add-doc-test?expand=1#diff-da8753d6fc68fc35c731952d0a43707d9576d2f486188b83e38f13d309d31a98)

### 🛠️ Testing Steps
- run :
```
scripts/run_test.sh
```