### PR TITLE
feat: standardize error types to conform to JSON-RPC

### DIFF
--- a/examples/mcp_client_handle_message.rs
+++ b/examples/mcp_client_handle_message.rs
@@ -2,7 +2,7 @@ use rust_mcp_schema::schema_utils::*;
 use rust_mcp_schema::*;
 use std::str::FromStr;
 
-type AppError = serde_json::error::Error;
+type AppError = JsonrpcErrorError;
 
 const SAMPLE_PAYLOAD: &str = r#"
 {

--- a/examples/mcp_server_handle_message.rs
+++ b/examples/mcp_server_handle_message.rs
@@ -2,7 +2,7 @@ use rust_mcp_schema::schema_utils::*;
 use rust_mcp_schema::*;
 use std::str::FromStr;
 
-type AppError = serde_json::error::Error;
+type AppError = JsonrpcErrorError;
 
 const SAMPLE_PAYLOAD: &str = r#"
 {

--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-14 07:43:44
+/// Generated at : 2025-02-14 08:18:40
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -89,7 +89,7 @@ impl Display for ClientJsonrpcRequest {
 }
 
 impl FromStr for ClientJsonrpcRequest {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     /// Parses a JSON-RPC request from a string.
     ///
@@ -101,7 +101,7 @@ impl FromStr for ClientJsonrpcRequest {
     ///
     /// # Returns
     /// * `Ok(ClientJsonrpcRequest)` if parsing is successful.
-    /// * `Err(serde_json::error::Error)` if the string is not valid JSON.
+    /// * `Err(JsonrpcErrorError)` if the string is not valid JSON.
     ///
     /// # Example
     /// ```
@@ -114,6 +114,7 @@ impl FromStr for ClientJsonrpcRequest {
     /// ```
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 
@@ -210,10 +211,11 @@ impl Display for ClientJsonrpcNotification {
 }
 
 impl FromStr for ClientJsonrpcNotification {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 
@@ -297,10 +299,11 @@ impl Display for ClientJsonrpcResponse {
 }
 
 impl FromStr for ClientJsonrpcResponse {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 //*******************************//
@@ -349,10 +352,11 @@ impl<'de> serde::Deserialize<'de> for ResultFromClient {
 //*******************************//
 
 impl FromStr for ClientMessage {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 
@@ -382,10 +386,11 @@ pub enum ServerMessage {
 }
 
 impl FromStr for ServerMessage {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 
@@ -436,10 +441,11 @@ impl Display for ServerJsonrpcRequest {
 }
 
 impl FromStr for ServerJsonrpcRequest {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 //*************************//
@@ -535,10 +541,11 @@ impl Display for ServerJsonrpcNotification {
 }
 
 impl FromStr for ServerJsonrpcNotification {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 //*******************************//
@@ -621,10 +628,11 @@ impl Display for ServerJsonrpcResponse {
 }
 
 impl FromStr for ServerJsonrpcResponse {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 //*******************************//
@@ -690,10 +698,11 @@ impl Display for JsonrpcError {
 }
 
 impl FromStr for JsonrpcError {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 
@@ -1386,9 +1395,10 @@ impl Display for JsonrpcErrorError {
     }
 }
 impl FromStr for JsonrpcErrorError {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 /// Constructs a new JsonrpcError using the provided arguments.

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-14 07:43:47
+/// Generated at : 2025-02-14 08:18:40
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -89,7 +89,7 @@ impl Display for ClientJsonrpcRequest {
 }
 
 impl FromStr for ClientJsonrpcRequest {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     /// Parses a JSON-RPC request from a string.
     ///
@@ -101,7 +101,7 @@ impl FromStr for ClientJsonrpcRequest {
     ///
     /// # Returns
     /// * `Ok(ClientJsonrpcRequest)` if parsing is successful.
-    /// * `Err(serde_json::error::Error)` if the string is not valid JSON.
+    /// * `Err(JsonrpcErrorError)` if the string is not valid JSON.
     ///
     /// # Example
     /// ```
@@ -114,6 +114,7 @@ impl FromStr for ClientJsonrpcRequest {
     /// ```
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 
@@ -210,10 +211,11 @@ impl Display for ClientJsonrpcNotification {
 }
 
 impl FromStr for ClientJsonrpcNotification {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 
@@ -297,10 +299,11 @@ impl Display for ClientJsonrpcResponse {
 }
 
 impl FromStr for ClientJsonrpcResponse {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 //*******************************//
@@ -349,10 +352,11 @@ impl<'de> serde::Deserialize<'de> for ResultFromClient {
 //*******************************//
 
 impl FromStr for ClientMessage {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 
@@ -382,10 +386,11 @@ pub enum ServerMessage {
 }
 
 impl FromStr for ServerMessage {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 
@@ -436,10 +441,11 @@ impl Display for ServerJsonrpcRequest {
 }
 
 impl FromStr for ServerJsonrpcRequest {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 //*************************//
@@ -535,10 +541,11 @@ impl Display for ServerJsonrpcNotification {
 }
 
 impl FromStr for ServerJsonrpcNotification {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 //*******************************//
@@ -621,10 +628,11 @@ impl Display for ServerJsonrpcResponse {
 }
 
 impl FromStr for ServerJsonrpcResponse {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 //*******************************//
@@ -690,10 +698,11 @@ impl Display for JsonrpcError {
 }
 
 impl FromStr for JsonrpcError {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 
@@ -1380,9 +1389,10 @@ impl Display for JsonrpcErrorError {
     }
 }
 impl FromStr for JsonrpcErrorError {
-    type Err = serde_json::error::Error;
+    type Err = JsonrpcErrorError;
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         serde_json::from_str(s)
+            .map_err(|error| JsonrpcErrorError::parse_error().with_data(Some(json!({ "details" : error.to_string() }))))
     }
 }
 /// Constructs a new JsonrpcError using the provided arguments.


### PR DESCRIPTION
### 📌 Summary
<!-- Provide a concise description of your changes. What problem does this PR solve? -->

We previously used `serde_json::error::Error` as the associated type for the `FromStr` trait. It has now been updated to return a consistent error type that aligns with the MCP specification.



### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- The FromStr trait implementations now return JsonrpcErrorError if parsing the message fails.
