### PR TITLE
feat: implement new utility functions

### DIFF
--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-14 08:18:40
+/// Generated at : 2025-02-17 17:12:03
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-17 17:12:03
+/// Generated at : 2025-02-17 17:23:32
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -1385,6 +1385,11 @@ impl JsonrpcErrorError {
         self
     }
 }
+impl std::error::Error for JsonrpcErrorError {
+    fn description(&self) -> &str {
+        &self.message
+    }
+}
 impl Display for JsonrpcErrorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-17 17:12:04
+/// Generated at : 2025-02-17 17:23:32
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-14 08:18:40
+/// Generated at : 2025-02-17 17:12:04
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -1379,6 +1379,11 @@ impl JsonrpcErrorError {
         self
     }
 }
+impl std::error::Error for JsonrpcErrorError {
+    fn description(&self) -> &str {
+        &self.message
+    }
+}
 impl Display for JsonrpcErrorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -37,6 +37,14 @@ mod test_serialize {
 
         let message: ClientMessage = re_serialize(message);
 
+        assert!(message.is_request());
+        assert!(!message.is_response());
+        assert!(!message.is_notification());
+        assert!(!message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
+
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::InitializeRequest(_)))
@@ -216,6 +224,14 @@ mod test_serialize {
 
         let message: ClientMessage = re_serialize(message);
 
+        assert!(!message.is_request());
+        assert!(message.is_response());
+        assert!(!message.is_notification());
+        assert!(!message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
+
         assert!(matches!(message, ClientMessage::Response(client_message)
                 if matches!(&client_message.result, ResultFromClient::ClientResult(client_result)
                         if matches!( client_result, ClientResult::CreateMessageResult(_))
@@ -258,6 +274,14 @@ mod test_serialize {
         ));
 
         let message: ServerMessage = re_serialize(message);
+
+        assert!(!message.is_request());
+        assert!(message.is_response());
+        assert!(!message.is_notification());
+        assert!(!message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
 
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
@@ -387,6 +411,13 @@ mod test_serialize {
 
         let message: ClientMessage = re_serialize(message);
 
+        assert!(!message.is_request());
+        assert!(!message.is_response());
+        assert!(message.is_notification());
+        assert!(!message.is_error());
+
+        assert!(message.request_id().is_none());
+
         assert!(matches!(message, ClientMessage::Notification(client_message)
         if matches!(&client_message.notification,NotificationFromClient::ClientNotification(client_notification)
                 if matches!( client_notification, ClientNotification::InitializedNotification(_)))
@@ -474,6 +505,13 @@ mod test_serialize {
 
         let message: ServerMessage = re_serialize(message);
 
+        assert!(!message.is_request());
+        assert!(!message.is_response());
+        assert!(message.is_notification());
+        assert!(!message.is_error());
+
+        assert!(message.request_id().is_none());
+
         assert!(matches!(message, ServerMessage::Notification(client_message)
                 if matches!(&client_message.notification,NotificationFromServer::ServerNotification(client_notification)
                 if matches!( client_notification, ServerNotification::CancelledNotification(_)))
@@ -518,6 +556,14 @@ mod test_serialize {
 
         let message: ServerMessage = re_serialize(message);
 
+        assert!(message.is_request());
+        assert!(!message.is_response());
+        assert!(!message.is_notification());
+        assert!(!message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
+
         assert!(matches!(message, ServerMessage::Request(server_message)
         if matches!(&server_message.request,RequestFromServer::ServerRequest(server_request)
                 if matches!( server_request, ServerRequest::CreateMessageRequest(_)))
@@ -559,6 +605,13 @@ mod test_serialize {
         let message: ClientMessage = re_serialize(message);
 
         assert!(matches!(message, ClientMessage::Error(_)));
+        assert!(!message.is_request());
+        assert!(!message.is_response());
+        assert!(!message.is_notification());
+        assert!(message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
 
         let message: ServerMessage = ServerMessage::Error(JsonrpcError::create(
             RequestId::Integer(15),
@@ -570,6 +623,14 @@ mod test_serialize {
         let message: ServerMessage = re_serialize(message);
 
         assert!(matches!(message, ServerMessage::Error(_)));
+
+        assert!(!message.is_request());
+        assert!(!message.is_response());
+        assert!(!message.is_notification());
+        assert!(message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
     }
 
     /* ---------------------- JsonrpcErrorError ---------------------- */


### PR DESCRIPTION
### 📌 Summary
<!-- Provide a concise description of your changes. What problem does this PR solve? -->

Added new utility functions to schema-utils to support MCP application development:

Added and implemented the `MCPMessage` trait with helpful methods, and provided implementations for `ClientMessage` and `ServerMessage`.

Implemented PartialEq, Eq, and Hash traits for requestId, enabling comparison and storage in HashMaps.


### 💡 Additional Notes

New functions provided by `MCPMessage` : 

- `message.is_request()` :    Returns true if the message is a response type
- `message.is_response()` : Returns true if the message is a request type
- `message.is_notification()` :  Returns true if the message is a notification type
- `message.is_error()` :  Returns true if the message represents an error
- `message.request_id()` :  Retrieves the request ID associated with the message, if applicable



### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Introduced and implemented `MCPMessage` trait for `ClientMessage` and `ServerMessage`
- Implemented `PartialEq` and `Eq` and `Hash` traits for `requestId`
- Change 3


