### PR TITLE
fix: serializations to skip None Params

### DIFF
--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-17 17:23:32
+/// Generated at : 2025-02-17 18:04:41
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-14 08:18:40
+/// Generated at : 2025-02-17 17:12:03
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-17 17:12:03
+/// Generated at : 2025-02-17 17:23:32
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -836,15 +836,31 @@ impl ::serde::Serialize for ClientJsonrpcRequest {
         match &self.request {
             RequestFromClient::ClientRequest(message) => match message {
                 InitializeRequest(msg) => state.serialize_field("params", &msg.params)?,
-                PingRequest(msg) => state.serialize_field("params", &msg.params)?,
+                PingRequest(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 ListResourcesRequest(msg) => state.serialize_field("params", &msg.params)?,
-                ListResourceTemplatesRequest(msg) => state.serialize_field("params", &msg.params)?,
+                ListResourceTemplatesRequest(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 ReadResourceRequest(msg) => state.serialize_field("params", &msg.params)?,
                 SubscribeRequest(msg) => state.serialize_field("params", &msg.params)?,
                 UnsubscribeRequest(msg) => state.serialize_field("params", &msg.params)?,
-                ListPromptsRequest(msg) => state.serialize_field("params", &msg.params)?,
+                ListPromptsRequest(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 GetPromptRequest(msg) => state.serialize_field("params", &msg.params)?,
-                ListToolsRequest(msg) => state.serialize_field("params", &msg.params)?,
+                ListToolsRequest(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 CallToolRequest(msg) => state.serialize_field("params", &msg.params)?,
                 SetLevelRequest(msg) => state.serialize_field("params", &msg.params)?,
                 CompleteRequest(msg) => state.serialize_field("params", &msg.params)?,
@@ -919,9 +935,17 @@ impl ::serde::Serialize for ServerJsonrpcRequest {
         use ServerRequest::*;
         match &self.request {
             RequestFromServer::ServerRequest(message) => match message {
-                PingRequest(msg) => state.serialize_field("params", &msg.params)?,
+                PingRequest(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 CreateMessageRequest(msg) => state.serialize_field("params", &msg.params)?,
-                ListRootsRequest(msg) => state.serialize_field("params", &msg.params)?,
+                ListRootsRequest(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
             },
             RequestFromServer::CustomRequest(value) => state.serialize_field("params", value)?,
         }
@@ -993,9 +1017,17 @@ impl ::serde::Serialize for ClientJsonrpcNotification {
         match &self.notification {
             NotificationFromClient::ClientNotification(message) => match message {
                 CancelledNotification(msg) => state.serialize_field("params", &msg.params)?,
-                InitializedNotification(msg) => state.serialize_field("params", &msg.params)?,
+                InitializedNotification(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 ProgressNotification(msg) => state.serialize_field("params", &msg.params)?,
-                RootsListChangedNotification(msg) => state.serialize_field("params", &msg.params)?,
+                RootsListChangedNotification(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
             },
             NotificationFromClient::CustomNotification(value) => state.serialize_field("params", value)?,
         }
@@ -1065,10 +1097,22 @@ impl ::serde::Serialize for ServerJsonrpcNotification {
             NotificationFromServer::ServerNotification(message) => match message {
                 CancelledNotification(msg) => state.serialize_field("params", &msg.params)?,
                 ProgressNotification(msg) => state.serialize_field("params", &msg.params)?,
-                ResourceListChangedNotification(msg) => state.serialize_field("params", &msg.params)?,
+                ResourceListChangedNotification(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 ResourceUpdatedNotification(msg) => state.serialize_field("params", &msg.params)?,
-                PromptListChangedNotification(msg) => state.serialize_field("params", &msg.params)?,
-                ToolListChangedNotification(msg) => state.serialize_field("params", &msg.params)?,
+                PromptListChangedNotification(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
+                ToolListChangedNotification(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 LoggingMessageNotification(msg) => state.serialize_field("params", &msg.params)?,
             },
             NotificationFromServer::CustomNotification(value) => state.serialize_field("params", value)?,

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -1385,6 +1385,11 @@ impl JsonrpcErrorError {
         self
     }
 }
+impl std::error::Error for JsonrpcErrorError {
+    fn description(&self) -> &str {
+        &self.message
+    }
+}
 impl Display for JsonrpcErrorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-17 17:12:04
+/// Generated at : 2025-02-17 17:23:32
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-14 08:18:40
+/// Generated at : 2025-02-17 17:12:04
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-17 17:23:32
+/// Generated at : 2025-02-17 18:04:41
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -836,14 +836,26 @@ impl ::serde::Serialize for ClientJsonrpcRequest {
         match &self.request {
             RequestFromClient::ClientRequest(message) => match message {
                 InitializeRequest(msg) => state.serialize_field("params", &msg.params)?,
-                PingRequest(msg) => state.serialize_field("params", &msg.params)?,
+                PingRequest(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 ListResourcesRequest(msg) => state.serialize_field("params", &msg.params)?,
                 ReadResourceRequest(msg) => state.serialize_field("params", &msg.params)?,
                 SubscribeRequest(msg) => state.serialize_field("params", &msg.params)?,
                 UnsubscribeRequest(msg) => state.serialize_field("params", &msg.params)?,
-                ListPromptsRequest(msg) => state.serialize_field("params", &msg.params)?,
+                ListPromptsRequest(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 GetPromptRequest(msg) => state.serialize_field("params", &msg.params)?,
-                ListToolsRequest(msg) => state.serialize_field("params", &msg.params)?,
+                ListToolsRequest(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 CallToolRequest(msg) => state.serialize_field("params", &msg.params)?,
                 SetLevelRequest(msg) => state.serialize_field("params", &msg.params)?,
                 CompleteRequest(msg) => state.serialize_field("params", &msg.params)?,
@@ -918,9 +930,17 @@ impl ::serde::Serialize for ServerJsonrpcRequest {
         use ServerRequest::*;
         match &self.request {
             RequestFromServer::ServerRequest(message) => match message {
-                PingRequest(msg) => state.serialize_field("params", &msg.params)?,
+                PingRequest(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 CreateMessageRequest(msg) => state.serialize_field("params", &msg.params)?,
-                ListRootsRequest(msg) => state.serialize_field("params", &msg.params)?,
+                ListRootsRequest(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
             },
             RequestFromServer::CustomRequest(value) => state.serialize_field("params", value)?,
         }
@@ -992,9 +1012,17 @@ impl ::serde::Serialize for ClientJsonrpcNotification {
         match &self.notification {
             NotificationFromClient::ClientNotification(message) => match message {
                 CancelledNotification(msg) => state.serialize_field("params", &msg.params)?,
-                InitializedNotification(msg) => state.serialize_field("params", &msg.params)?,
+                InitializedNotification(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 ProgressNotification(msg) => state.serialize_field("params", &msg.params)?,
-                RootsListChangedNotification(msg) => state.serialize_field("params", &msg.params)?,
+                RootsListChangedNotification(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
             },
             NotificationFromClient::CustomNotification(value) => state.serialize_field("params", value)?,
         }
@@ -1064,10 +1092,22 @@ impl ::serde::Serialize for ServerJsonrpcNotification {
             NotificationFromServer::ServerNotification(message) => match message {
                 CancelledNotification(msg) => state.serialize_field("params", &msg.params)?,
                 ProgressNotification(msg) => state.serialize_field("params", &msg.params)?,
-                ResourceListChangedNotification(msg) => state.serialize_field("params", &msg.params)?,
+                ResourceListChangedNotification(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 ResourceUpdatedNotification(msg) => state.serialize_field("params", &msg.params)?,
-                PromptListChangedNotification(msg) => state.serialize_field("params", &msg.params)?,
-                ToolListChangedNotification(msg) => state.serialize_field("params", &msg.params)?,
+                PromptListChangedNotification(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
+                ToolListChangedNotification(msg) => {
+                    if let Some(params) = &msg.params {
+                        state.serialize_field("params", params)?
+                    }
+                }
                 LoggingMessageNotification(msg) => state.serialize_field("params", &msg.params)?,
             },
             NotificationFromServer::CustomNotification(value) => state.serialize_field("params", value)?,

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -1379,6 +1379,11 @@ impl JsonrpcErrorError {
         self
     }
 }
+impl std::error::Error for JsonrpcErrorError {
+    fn description(&self) -> &str {
+        &self.message
+    }
+}
 impl Display for JsonrpcErrorError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -37,6 +37,14 @@ mod test_serialize {
 
         let message: ClientMessage = re_serialize(message);
 
+        assert!(message.is_request());
+        assert!(!message.is_response());
+        assert!(!message.is_notification());
+        assert!(!message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
+
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::InitializeRequest(_)))
@@ -216,6 +224,14 @@ mod test_serialize {
 
         let message: ClientMessage = re_serialize(message);
 
+        assert!(!message.is_request());
+        assert!(message.is_response());
+        assert!(!message.is_notification());
+        assert!(!message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
+
         assert!(matches!(message, ClientMessage::Response(client_message)
                 if matches!(&client_message.result, ResultFromClient::ClientResult(client_result)
                         if matches!( client_result, ClientResult::CreateMessageResult(_))
@@ -258,6 +274,14 @@ mod test_serialize {
         ));
 
         let message: ServerMessage = re_serialize(message);
+
+        assert!(!message.is_request());
+        assert!(message.is_response());
+        assert!(!message.is_notification());
+        assert!(!message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
 
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
@@ -387,6 +411,13 @@ mod test_serialize {
 
         let message: ClientMessage = re_serialize(message);
 
+        assert!(!message.is_request());
+        assert!(!message.is_response());
+        assert!(message.is_notification());
+        assert!(!message.is_error());
+
+        assert!(message.request_id().is_none());
+
         assert!(matches!(message, ClientMessage::Notification(client_message)
         if matches!(&client_message.notification,NotificationFromClient::ClientNotification(client_notification)
                 if matches!( client_notification, ClientNotification::InitializedNotification(_)))
@@ -474,6 +505,13 @@ mod test_serialize {
 
         let message: ServerMessage = re_serialize(message);
 
+        assert!(!message.is_request());
+        assert!(!message.is_response());
+        assert!(message.is_notification());
+        assert!(!message.is_error());
+
+        assert!(message.request_id().is_none());
+
         assert!(matches!(message, ServerMessage::Notification(client_message)
                 if matches!(&client_message.notification,NotificationFromServer::ServerNotification(client_notification)
                 if matches!( client_notification, ServerNotification::CancelledNotification(_)))
@@ -518,6 +556,14 @@ mod test_serialize {
 
         let message: ServerMessage = re_serialize(message);
 
+        assert!(message.is_request());
+        assert!(!message.is_response());
+        assert!(!message.is_notification());
+        assert!(!message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
+
         assert!(matches!(message, ServerMessage::Request(server_message)
         if matches!(&server_message.request,RequestFromServer::ServerRequest(server_request)
                 if matches!( server_request, ServerRequest::CreateMessageRequest(_)))
@@ -559,6 +605,13 @@ mod test_serialize {
         let message: ClientMessage = re_serialize(message);
 
         assert!(matches!(message, ClientMessage::Error(_)));
+        assert!(!message.is_request());
+        assert!(!message.is_response());
+        assert!(!message.is_notification());
+        assert!(message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
 
         let message: ServerMessage = ServerMessage::Error(JsonrpcError::create(
             RequestId::Integer(15),
@@ -570,6 +623,14 @@ mod test_serialize {
         let message: ServerMessage = re_serialize(message);
 
         assert!(matches!(message, ServerMessage::Error(_)));
+
+        assert!(!message.is_request());
+        assert!(!message.is_response());
+        assert!(!message.is_notification());
+        assert!(message.is_error());
+        assert!(
+            matches!(message.request_id(), Some(request_id) if matches!(request_id , RequestId::Integer(r) if *r == 15))
+        );
     }
 
     /* ---------------------- JsonrpcErrorError ---------------------- */


### PR DESCRIPTION
### 📌 Summary
<!-- Provide a concise description of your changes. What problem does this PR solve? -->

Resolved an issue where our custom serializer failed to skip optional parameters with a `None` value, resulting in invalid JSON with null that was rejected by MCP schema validation.

### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Updated Serialize trait implementations to skip serializing `Option` params with `None` value
