### PR TITLE
fix: made jsonrpc field private, fix test script

### DIFF
--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -12,6 +12,13 @@ COMMON_FEATURES_STR="${COMMON_FEATURES[*]}"
 for FEATURE in "${SCHEMA_VERSION_FEATURES[@]}"; do
     echo "🚀 Running tests with: --features \"$COMMON_FEATURES_STR $FEATURE\""
     cargo nextest run --no-default-features --features "$COMMON_FEATURES_STR $FEATURE"
+
+    # stop on failure
+    if [ $? -ne 0 ]; then
+        echo "❌ Tests failed for: --features \"$COMMON_FEATURES_STR $FEATURE\""
+        exit 1
+    fi
+    
     echo
     echo "🚀 Running documentation tests with: --features \"$COMMON_FEATURES_STR $FEATURE\""
     cargo test --doc --no-default-features --features "$COMMON_FEATURES_STR $FEATURE"

--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -5,8 +5,8 @@
 /// modify or extend the implementations as needed, but please do so at your own risk.
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
-/// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-18 08:30:28
+/// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
+/// Generated at : 2025-02-19 06:30:55
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -5,8 +5,8 @@
 /// modify or extend the implementations as needed, but please do so at your own risk.
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
-/// Hash : 63e1dbb75456b359b9ed8b27d21f4ac68cbb753e
-/// Generated at : 2025-02-18 08:30:28
+/// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
+/// Generated at : 2025-02-19 06:30:55
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -18,7 +18,7 @@ mod test_deserialize {
 
         if let ClientMessage::Request(client_message) = message {
             matches!(&client_message.id, &RequestId::Integer(0));
-            assert_eq!(client_message.jsonrpc, JSONRPC_VERSION);
+            assert_eq!(client_message.jsonrpc(), JSONRPC_VERSION);
             assert_eq!(client_message.method, "initialize");
 
             if let RequestFromClient::ClientRequest(ClientRequest::InitializeRequest(request)) = client_message.request {


### PR DESCRIPTION
### 📌 Summary
<!-- Provide a concise description of your changes. What problem does this PR solve? -->
- Added jsonrpc() method to the `RPCMessage` trait
- Made `jsonrpc` field private in `schema_utils`
- Fixed test script to check exit code o both nextext ad doctest
