### PR TITLE
feat: introduce FromMessage trait

### DIFF
--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-02-19 17:00:34
+/// Generated at : 2025-02-19 19:59:01
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-02-19 17:00:35
+/// Generated at : 2025-02-19 19:59:01
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version


### PR DESCRIPTION
### 📌 Summary
<!-- Provide a concise description of your changes. What problem does this PR solve? -->
Introduced a new trait named `FromMessage`, this is useful for transforming mcp messages into another Type that could be serialized into a JsonrpcMessage.

 For example, a `ServerMessage` can be constructed from a `rust_mcp_schema::PingRequest` by attaching a `RequestId`.
Eventually, the `ServerMessage` can be serialized into a valid `JsonrpcMessage` for transmission over the transport.

### Example:
```rs
async fn send_ping_request(ping_request: rust_mcp_schema::PingRequest){

    let request_id = get_next_id();

    // construct a ServerMessage from the ping_request , with request_id
    let message = ServerMessage::from_message(
        MessageFromServer::RequestFromServer(ping_request.into()),
        request_id,
    ).unwrap();

    // serialize message into a valid rpcJsonrpcMessage string
    let rpc_message_json_str = message.to_string();

    // send the ping request to the client
    tranport.send(rpc_message_json_str).await

}

```
