### PR TITLE
feat: new try_from functions for all standard mcp message variants

### DIFF
--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-02-20 19:37:53
+/// Generated at : 2025-02-22 11:26:40
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-02-22 11:26:40
+/// Generated at : 2025-02-22 11:48:41
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -154,13 +154,11 @@ impl ClientMessage {
         if let Self::Response(response) = self {
             Ok(response)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Response,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Response,
+                self.message_type()
+            )))
         }
     }
 
@@ -177,13 +175,11 @@ impl ClientMessage {
         if let Self::Request(request) = self {
             Ok(request)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Request,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Request,
+                self.message_type()
+            )))
         }
     }
 
@@ -200,13 +196,11 @@ impl ClientMessage {
         if let Self::Notification(notification) = self {
             Ok(notification)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Notification,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Notification,
+                self.message_type()
+            )))
         }
     }
 
@@ -223,13 +217,11 @@ impl ClientMessage {
         if let Self::Error(error) = self {
             Ok(error)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Error,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Error,
+                self.message_type()
+            )))
         }
     }
 }
@@ -681,13 +673,11 @@ impl ServerMessage {
         if let Self::Response(response) = self {
             Ok(response)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Response,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Response,
+                self.message_type()
+            )))
         }
     }
 
@@ -704,13 +694,11 @@ impl ServerMessage {
         if let Self::Request(request) = self {
             Ok(request)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Request,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Request,
+                self.message_type()
+            )))
         }
     }
 
@@ -727,13 +715,11 @@ impl ServerMessage {
         if let Self::Notification(notification) = self {
             Ok(notification)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Notification,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Notification,
+                self.message_type()
+            )))
         }
     }
 
@@ -750,13 +736,11 @@ impl ServerMessage {
         if let Self::Error(error) = self {
             Ok(error)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Error,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Error,
+                self.message_type()
+            )))
         }
     }
 }

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -154,11 +154,12 @@ impl ClientMessage {
         if let Self::Response(response) = self {
             Ok(response)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Response,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Response,
+                    self.message_type()
+                )))
         }
     }
 
@@ -175,11 +176,12 @@ impl ClientMessage {
         if let Self::Request(request) = self {
             Ok(request)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Request,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Request,
+                    self.message_type()
+                )))
         }
     }
 
@@ -196,11 +198,13 @@ impl ClientMessage {
         if let Self::Notification(notification) = self {
             Ok(notification)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Notification,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Notification,
+                    self.message_type()
+                ))
+                )
         }
     }
 
@@ -217,11 +221,13 @@ impl ClientMessage {
         if let Self::Error(error) = self {
             Ok(error)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Error,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Error,
+                    self.message_type()
+                ))
+                )
         }
     }
 }
@@ -673,11 +679,12 @@ impl ServerMessage {
         if let Self::Response(response) = self {
             Ok(response)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Response,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Response,
+                    self.message_type()
+                )))
         }
     }
 
@@ -694,11 +701,13 @@ impl ServerMessage {
         if let Self::Request(request) = self {
             Ok(request)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Request,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Request,
+                    self.message_type()
+                ))
+                )
         }
     }
 
@@ -715,11 +724,13 @@ impl ServerMessage {
         if let Self::Notification(notification) = self {
             Ok(notification)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Notification,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Notification,
+                    self.message_type()
+                ))
+                )
         }
     }
 
@@ -736,11 +747,13 @@ impl ServerMessage {
         if let Self::Error(error) = self {
             Ok(error)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Error,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Error,
+                    self.message_type()
+                ))
+                )
         }
     }
 }
@@ -3043,6 +3056,446 @@ impl FromMessage<LoggingMessageNotification> for ServerMessage {
 impl ToMessage<ServerMessage> for LoggingMessageNotification {
     fn to_message(self, request_id: Option<RequestId>) -> std::result::Result<ServerMessage, JsonrpcErrorError> {
         ServerMessage::from_message(self, request_id)
+    }
+}
+impl TryFrom<RequestFromClient> for InitializeRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::InitializeRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a InitializeRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for PingRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::PingRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a PingRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for ListResourcesRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::ListResourcesRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListResourcesRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for ListResourceTemplatesRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::ListResourceTemplatesRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListResourceTemplatesRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for ReadResourceRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::ReadResourceRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ReadResourceRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for SubscribeRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::SubscribeRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a SubscribeRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for UnsubscribeRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::UnsubscribeRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a UnsubscribeRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for ListPromptsRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::ListPromptsRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListPromptsRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for GetPromptRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::GetPromptRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a GetPromptRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for ListToolsRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::ListToolsRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListToolsRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for CallToolRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::CallToolRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CallToolRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for SetLevelRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::SetLevelRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a SetLevelRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for CompleteRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::CompleteRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CompleteRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromClient> for Result {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientResult = value.try_into()?;
+        if let ClientResult::Result(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a Result".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromClient> for CreateMessageResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientResult = value.try_into()?;
+        if let ClientResult::CreateMessageResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CreateMessageResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromClient> for ListRootsResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientResult = value.try_into()?;
+        if let ClientResult::ListRootsResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListRootsResult".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromClient> for CancelledNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientNotification = value.try_into()?;
+        if let ClientNotification::CancelledNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CancelledNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromClient> for InitializedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientNotification = value.try_into()?;
+        if let ClientNotification::InitializedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a InitializedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromClient> for ProgressNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientNotification = value.try_into()?;
+        if let ClientNotification::ProgressNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ProgressNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromClient> for RootsListChangedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientNotification = value.try_into()?;
+        if let ClientNotification::RootsListChangedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a RootsListChangedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromServer> for PingRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerRequest = value.try_into()?;
+        if let ServerRequest::PingRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a PingRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromServer> for CreateMessageRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerRequest = value.try_into()?;
+        if let ServerRequest::CreateMessageRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CreateMessageRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromServer> for ListRootsRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerRequest = value.try_into()?;
+        if let ServerRequest::ListRootsRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListRootsRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for Result {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::Result(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a Result".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for InitializeResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::InitializeResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a InitializeResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for ListResourcesResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::ListResourcesResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListResourcesResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for ListResourceTemplatesResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::ListResourceTemplatesResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListResourceTemplatesResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for ReadResourceResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::ReadResourceResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ReadResourceResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for ListPromptsResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::ListPromptsResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListPromptsResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for GetPromptResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::GetPromptResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a GetPromptResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for ListToolsResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::ListToolsResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListToolsResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for CallToolResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::CallToolResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CallToolResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for CompleteResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::CompleteResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CompleteResult".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for CancelledNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::CancelledNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CancelledNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for ProgressNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::ProgressNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ProgressNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for ResourceListChangedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::ResourceListChangedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ResourceListChangedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for ResourceUpdatedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::ResourceUpdatedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ResourceUpdatedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for PromptListChangedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::PromptListChangedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a PromptListChangedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for ToolListChangedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::ToolListChangedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ToolListChangedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for LoggingMessageNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::LoggingMessageNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a LoggingMessageNotification".to_string()))
+        }
     }
 }
 /// END AUTO GENERATED

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -2,6 +2,7 @@ use crate::generated_schema::*;
 use serde::ser::SerializeStruct;
 use serde_json::{json, Value};
 use std::hash::{Hash, Hasher};
+use std::result;
 use std::{fmt::Display, str::FromStr};
 
 #[derive(Debug, PartialEq)]
@@ -137,6 +138,100 @@ pub enum ClientMessage {
     Notification(ClientJsonrpcNotification),
     Response(ClientJsonrpcResponse),
     Error(JsonrpcError),
+}
+
+impl ClientMessage {
+    /// Converts the current message into a `ClientJsonrpcResponse` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Response`. If so, it returns the
+    /// `ClientJsonrpcResponse` wrapped in a `Result::Ok`. If the message is not a `Response`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ClientJsonrpcResponse)` if the message is a valid `Response`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_response(self) -> std::result::Result<ClientJsonrpcResponse, JsonrpcErrorError> {
+        if let Self::Response(response) = self {
+            Ok(response)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Response,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `ClientJsonrpcRequest` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Request`. If so, it returns the
+    /// `ClientJsonrpcRequest` wrapped in a `Result::Ok`. If the message is not a `Request`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ClientJsonrpcRequest)` if the message is a valid `Request`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_request(self) -> std::result::Result<ClientJsonrpcRequest, JsonrpcErrorError> {
+        if let Self::Request(request) = self {
+            Ok(request)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Request,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `ClientJsonrpcNotification` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Notification`. If so, it returns the
+    /// `ClientJsonrpcNotification` wrapped in a `Result::Ok`. If the message is not a `Notification`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ClientJsonrpcNotification)` if the message is a valid `Notification`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_notification(self) -> std::result::Result<ClientJsonrpcNotification, JsonrpcErrorError> {
+        if let Self::Notification(notification) = self {
+            Ok(notification)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Notification,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `JsonrpcError` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Error`. If so, it returns the
+    /// `JsonrpcError` wrapped in a `Result::Ok`. If the message is not a `Error`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(JsonrpcError)` if the message is a valid `Error`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_error(self) -> std::result::Result<JsonrpcError, JsonrpcErrorError> {
+        if let Self::Error(error) = self {
+            Ok(error)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Error,
+                    self.message_type()
+                ))
+                )
+        }
+    }
 }
 
 impl RPCMessage for ClientMessage {
@@ -279,6 +374,17 @@ pub enum RequestFromClient {
     CustomRequest(serde_json::Value),
 }
 
+impl TryFrom<RequestFromClient> for ClientRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> result::Result<Self, Self::Error> {
+        if let RequestFromClient::ClientRequest(client_request) = value {
+            Ok(client_request)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ClientRequest".to_string()))
+        }
+    }
+}
+
 impl RequestFromClient {
     #[deprecated(since = "0.1.4", note = "Use `method()` instead.")]
     pub fn get_method(&self) -> &str {
@@ -383,6 +489,17 @@ pub enum NotificationFromClient {
     CustomNotification(serde_json::Value),
 }
 
+impl TryFrom<NotificationFromClient> for ClientNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromClient) -> result::Result<Self, Self::Error> {
+        if let NotificationFromClient::ClientNotification(client_notification) = value {
+            Ok(client_notification)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ClientNotification".to_string()))
+        }
+    }
+}
+
 impl NotificationFromClient {
     #[deprecated(since = "0.1.4", note = "Use `method()` instead.")]
     pub fn get_method(&self) -> &str {
@@ -473,6 +590,17 @@ pub enum ResultFromClient {
     CustomResult(serde_json::Value),
 }
 
+impl TryFrom<ResultFromClient> for ClientResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromClient) -> result::Result<Self, Self::Error> {
+        if let ResultFromClient::ClientResult(client_result) = value {
+            Ok(client_result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ClientResult".to_string()))
+        }
+    }
+}
+
 impl From<ClientResult> for ResultFromClient {
     fn from(value: ClientResult) -> Self {
         Self::ClientResult(value)
@@ -539,16 +667,110 @@ pub enum ServerMessage {
     Error(JsonrpcError),
 }
 
+impl ServerMessage {
+    /// Converts the current message into a `ServerJsonrpcResponse` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Response`. If so, it returns the
+    /// `ServerJsonrpcResponse` wrapped in a `Result::Ok`. If the message is not a `Response`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ServerJsonrpcResponse)` if the message is a valid `Response`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_response(self) -> std::result::Result<ServerJsonrpcResponse, JsonrpcErrorError> {
+        if let Self::Response(response) = self {
+            Ok(response)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Response,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `ServerJsonrpcRequest` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Request`. If so, it returns the
+    /// `ServerJsonrpcRequest` wrapped in a `Result::Ok`. If the message is not a `Request`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ServerJsonrpcRequest)` if the message is a valid `Request`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_request(self) -> std::result::Result<ServerJsonrpcRequest, JsonrpcErrorError> {
+        if let Self::Request(request) = self {
+            Ok(request)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Request,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `ServerJsonrpcNotification` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Notification`. If so, it returns the
+    /// `ServerJsonrpcNotification` wrapped in a `Result::Ok`. If the message is not a `Notification`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ServerJsonrpcNotification)` if the message is a valid `Notification`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_notification(self) -> std::result::Result<ServerJsonrpcNotification, JsonrpcErrorError> {
+        if let Self::Notification(notification) = self {
+            Ok(notification)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Notification,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `JsonrpcError` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Error`. If so, it returns the
+    /// `JsonrpcError` wrapped in a `Result::Ok`. If the message is not a `Error`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(JsonrpcError)` if the message is a valid `Error`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_error(self) -> std::result::Result<JsonrpcError, JsonrpcErrorError> {
+        if let Self::Error(error) = self {
+            Ok(error)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Error,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+}
+
 impl RPCMessage for ServerMessage {
     // Retrieves the request ID associated with the message, if applicable
     fn request_id(&self) -> Option<&RequestId> {
         match self {
             // If the message is a request, return the associated request ID
-            ServerMessage::Request(client_jsonrpc_request) => Some(&client_jsonrpc_request.id),
+            ServerMessage::Request(server_jsonrpc_request) => Some(&server_jsonrpc_request.id),
             // Notifications do not have request IDs
             ServerMessage::Notification(_) => None,
             // If the message is a response, return the associated request ID
-            ServerMessage::Response(client_jsonrpc_response) => Some(&client_jsonrpc_response.id),
+            ServerMessage::Response(server_jsonrpc_response) => Some(&server_jsonrpc_response.id),
             // If the message is an error, return the associated request ID
             ServerMessage::Error(jsonrpc_error) => Some(&jsonrpc_error.id),
         }
@@ -557,11 +779,11 @@ impl RPCMessage for ServerMessage {
     fn jsonrpc(&self) -> &str {
         match self {
             // If the message is a request, return the associated request ID
-            ServerMessage::Request(client_jsonrpc_request) => client_jsonrpc_request.jsonrpc(),
+            ServerMessage::Request(server_jsonrpc_request) => server_jsonrpc_request.jsonrpc(),
             // Notifications do not have request IDs
             ServerMessage::Notification(notification) => notification.jsonrpc(),
             // If the message is a response, return the associated request ID
-            ServerMessage::Response(client_jsonrpc_response) => client_jsonrpc_response.jsonrpc(),
+            ServerMessage::Response(server_jsonrpc_response) => server_jsonrpc_response.jsonrpc(),
             // If the message is an error, return the associated request ID
             ServerMessage::Error(jsonrpc_error) => jsonrpc_error.jsonrpc(),
         }
@@ -680,6 +902,17 @@ pub enum RequestFromServer {
     CustomRequest(serde_json::Value),
 }
 
+impl TryFrom<RequestFromServer> for ServerRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromServer) -> result::Result<Self, Self::Error> {
+        if let RequestFromServer::ServerRequest(server_request) = value {
+            Ok(server_request)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ServerRequest".to_string()))
+        }
+    }
+}
+
 impl RequestFromServer {
     #[deprecated(since = "0.1.4", note = "Use `method()` instead.")]
     pub fn get_method(&self) -> &str {
@@ -783,6 +1016,17 @@ pub enum NotificationFromServer {
     CustomNotification(serde_json::Value),
 }
 
+impl TryFrom<NotificationFromServer> for ServerNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> result::Result<Self, Self::Error> {
+        if let NotificationFromServer::ServerNotification(server_notification) = value {
+            Ok(server_notification)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ServerNotification".to_string()))
+        }
+    }
+}
+
 impl NotificationFromServer {
     #[deprecated(since = "0.1.4", note = "Use `method()` instead.")]
     pub fn get_method(&self) -> &str {
@@ -871,6 +1115,17 @@ impl FromStr for ServerJsonrpcResponse {
 pub enum ResultFromServer {
     ServerResult(ServerResult),
     CustomResult(serde_json::Value),
+}
+
+impl TryFrom<ResultFromServer> for ServerResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> result::Result<Self, Self::Error> {
+        if let ResultFromServer::ServerResult(server_result) = value {
+            Ok(server_result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ServerResult".to_string()))
+        }
+    }
 }
 
 impl From<ServerResult> for ResultFromServer {

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-02-20 19:37:53
+/// Generated at : 2025-02-22 11:26:41
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-02-22 11:26:41
+/// Generated at : 2025-02-22 11:48:41
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -154,13 +154,11 @@ impl ClientMessage {
         if let Self::Response(response) = self {
             Ok(response)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Response,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Response,
+                self.message_type()
+            )))
         }
     }
 
@@ -177,13 +175,11 @@ impl ClientMessage {
         if let Self::Request(request) = self {
             Ok(request)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Request,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Request,
+                self.message_type()
+            )))
         }
     }
 
@@ -200,13 +196,11 @@ impl ClientMessage {
         if let Self::Notification(notification) = self {
             Ok(notification)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Notification,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Notification,
+                self.message_type()
+            )))
         }
     }
 
@@ -223,13 +217,11 @@ impl ClientMessage {
         if let Self::Error(error) = self {
             Ok(error)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Error,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Error,
+                self.message_type()
+            )))
         }
     }
 }
@@ -681,13 +673,11 @@ impl ServerMessage {
         if let Self::Response(response) = self {
             Ok(response)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Response,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Response,
+                self.message_type()
+            )))
         }
     }
 
@@ -704,13 +694,11 @@ impl ServerMessage {
         if let Self::Request(request) = self {
             Ok(request)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Request,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Request,
+                self.message_type()
+            )))
         }
     }
 
@@ -727,13 +715,11 @@ impl ServerMessage {
         if let Self::Notification(notification) = self {
             Ok(notification)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Notification,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Notification,
+                self.message_type()
+            )))
         }
     }
 
@@ -750,13 +736,11 @@ impl ServerMessage {
         if let Self::Error(error) = self {
             Ok(error)
         } else {
-            Err(JsonrpcErrorError::internal_error()
-                .with_message(format!(
-                    "Invalid message type, expected: \"{}\" received\"{}\"",
-                    MessageTypes::Error,
-                    self.message_type()
-                ))
-                )
+            Err(JsonrpcErrorError::internal_error().with_message(format!(
+                "Invalid message type, expected: \"{}\" received\"{}\"",
+                MessageTypes::Error,
+                self.message_type()
+            )))
         }
     }
 }

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -154,11 +154,12 @@ impl ClientMessage {
         if let Self::Response(response) = self {
             Ok(response)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Response,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Response,
+                    self.message_type()
+                )))
         }
     }
 
@@ -175,11 +176,12 @@ impl ClientMessage {
         if let Self::Request(request) = self {
             Ok(request)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Request,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Request,
+                    self.message_type()
+                )))
         }
     }
 
@@ -196,11 +198,13 @@ impl ClientMessage {
         if let Self::Notification(notification) = self {
             Ok(notification)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Notification,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Notification,
+                    self.message_type()
+                ))
+                )
         }
     }
 
@@ -217,11 +221,13 @@ impl ClientMessage {
         if let Self::Error(error) = self {
             Ok(error)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Error,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Error,
+                    self.message_type()
+                ))
+                )
         }
     }
 }
@@ -673,11 +679,12 @@ impl ServerMessage {
         if let Self::Response(response) = self {
             Ok(response)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Response,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Response,
+                    self.message_type()
+                )))
         }
     }
 
@@ -694,11 +701,13 @@ impl ServerMessage {
         if let Self::Request(request) = self {
             Ok(request)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Request,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Request,
+                    self.message_type()
+                ))
+                )
         }
     }
 
@@ -715,11 +724,13 @@ impl ServerMessage {
         if let Self::Notification(notification) = self {
             Ok(notification)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Notification,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Notification,
+                    self.message_type()
+                ))
+                )
         }
     }
 
@@ -736,11 +747,13 @@ impl ServerMessage {
         if let Self::Error(error) = self {
             Ok(error)
         } else {
-            Err(JsonrpcErrorError::internal_error().with_message(format!(
-                "Invalid message type, expected: \"{}\" received\"{}\"",
-                MessageTypes::Error,
-                self.message_type()
-            )))
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Error,
+                    self.message_type()
+                ))
+                )
         }
     }
 }
@@ -2985,6 +2998,424 @@ impl FromMessage<LoggingMessageNotification> for ServerMessage {
 impl ToMessage<ServerMessage> for LoggingMessageNotification {
     fn to_message(self, request_id: Option<RequestId>) -> std::result::Result<ServerMessage, JsonrpcErrorError> {
         ServerMessage::from_message(self, request_id)
+    }
+}
+impl TryFrom<RequestFromClient> for InitializeRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::InitializeRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a InitializeRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for PingRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::PingRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a PingRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for ListResourcesRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::ListResourcesRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListResourcesRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for ReadResourceRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::ReadResourceRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ReadResourceRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for SubscribeRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::SubscribeRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a SubscribeRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for UnsubscribeRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::UnsubscribeRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a UnsubscribeRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for ListPromptsRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::ListPromptsRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListPromptsRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for GetPromptRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::GetPromptRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a GetPromptRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for ListToolsRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::ListToolsRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListToolsRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for CallToolRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::CallToolRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CallToolRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for SetLevelRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::SetLevelRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a SetLevelRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromClient> for CompleteRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientRequest = value.try_into()?;
+        if let ClientRequest::CompleteRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CompleteRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromClient> for Result {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientResult = value.try_into()?;
+        if let ClientResult::Result(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a Result".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromClient> for CreateMessageResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientResult = value.try_into()?;
+        if let ClientResult::CreateMessageResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CreateMessageResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromClient> for ListRootsResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientResult = value.try_into()?;
+        if let ClientResult::ListRootsResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListRootsResult".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromClient> for CancelledNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientNotification = value.try_into()?;
+        if let ClientNotification::CancelledNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CancelledNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromClient> for InitializedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientNotification = value.try_into()?;
+        if let ClientNotification::InitializedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a InitializedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromClient> for ProgressNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientNotification = value.try_into()?;
+        if let ClientNotification::ProgressNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ProgressNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromClient> for RootsListChangedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromClient) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ClientNotification = value.try_into()?;
+        if let ClientNotification::RootsListChangedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a RootsListChangedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromServer> for PingRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerRequest = value.try_into()?;
+        if let ServerRequest::PingRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a PingRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromServer> for CreateMessageRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerRequest = value.try_into()?;
+        if let ServerRequest::CreateMessageRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CreateMessageRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<RequestFromServer> for ListRootsRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerRequest = value.try_into()?;
+        if let ServerRequest::ListRootsRequest(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListRootsRequest".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for Result {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::Result(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a Result".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for InitializeResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::InitializeResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a InitializeResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for ListResourcesResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::ListResourcesResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListResourcesResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for ReadResourceResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::ReadResourceResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ReadResourceResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for ListPromptsResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::ListPromptsResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListPromptsResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for GetPromptResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::GetPromptResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a GetPromptResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for ListToolsResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::ListToolsResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ListToolsResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for CallToolResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::CallToolResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CallToolResult".to_string()))
+        }
+    }
+}
+impl TryFrom<ResultFromServer> for CompleteResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerResult = value.try_into()?;
+        if let ServerResult::CompleteResult(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CompleteResult".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for CancelledNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::CancelledNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a CancelledNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for ProgressNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::ProgressNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ProgressNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for ResourceListChangedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::ResourceListChangedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ResourceListChangedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for ResourceUpdatedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::ResourceUpdatedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ResourceUpdatedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for PromptListChangedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::PromptListChangedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a PromptListChangedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for ToolListChangedNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::ToolListChangedNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ToolListChangedNotification".to_string()))
+        }
+    }
+}
+impl TryFrom<NotificationFromServer> for LoggingMessageNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> std::result::Result<Self, Self::Error> {
+        let matched_type: ServerNotification = value.try_into()?;
+        if let ServerNotification::LoggingMessageNotification(result) = matched_type {
+            Ok(result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a LoggingMessageNotification".to_string()))
+        }
     }
 }
 /// END AUTO GENERATED

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -2,6 +2,7 @@ use crate::generated_schema::*;
 use serde::ser::SerializeStruct;
 use serde_json::{json, Value};
 use std::hash::{Hash, Hasher};
+use std::result;
 use std::{fmt::Display, str::FromStr};
 
 #[derive(Debug, PartialEq)]
@@ -137,6 +138,100 @@ pub enum ClientMessage {
     Notification(ClientJsonrpcNotification),
     Response(ClientJsonrpcResponse),
     Error(JsonrpcError),
+}
+
+impl ClientMessage {
+    /// Converts the current message into a `ClientJsonrpcResponse` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Response`. If so, it returns the
+    /// `ClientJsonrpcResponse` wrapped in a `Result::Ok`. If the message is not a `Response`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ClientJsonrpcResponse)` if the message is a valid `Response`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_response(self) -> std::result::Result<ClientJsonrpcResponse, JsonrpcErrorError> {
+        if let Self::Response(response) = self {
+            Ok(response)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Response,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `ClientJsonrpcRequest` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Request`. If so, it returns the
+    /// `ClientJsonrpcRequest` wrapped in a `Result::Ok`. If the message is not a `Request`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ClientJsonrpcRequest)` if the message is a valid `Request`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_request(self) -> std::result::Result<ClientJsonrpcRequest, JsonrpcErrorError> {
+        if let Self::Request(request) = self {
+            Ok(request)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Request,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `ClientJsonrpcNotification` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Notification`. If so, it returns the
+    /// `ClientJsonrpcNotification` wrapped in a `Result::Ok`. If the message is not a `Notification`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ClientJsonrpcNotification)` if the message is a valid `Notification`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_notification(self) -> std::result::Result<ClientJsonrpcNotification, JsonrpcErrorError> {
+        if let Self::Notification(notification) = self {
+            Ok(notification)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Notification,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `JsonrpcError` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Error`. If so, it returns the
+    /// `JsonrpcError` wrapped in a `Result::Ok`. If the message is not a `Error`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(JsonrpcError)` if the message is a valid `Error`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_error(self) -> std::result::Result<JsonrpcError, JsonrpcErrorError> {
+        if let Self::Error(error) = self {
+            Ok(error)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Error,
+                    self.message_type()
+                ))
+                )
+        }
+    }
 }
 
 impl RPCMessage for ClientMessage {
@@ -279,6 +374,17 @@ pub enum RequestFromClient {
     CustomRequest(serde_json::Value),
 }
 
+impl TryFrom<RequestFromClient> for ClientRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromClient) -> result::Result<Self, Self::Error> {
+        if let RequestFromClient::ClientRequest(client_request) = value {
+            Ok(client_request)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ClientRequest".to_string()))
+        }
+    }
+}
+
 impl RequestFromClient {
     #[deprecated(since = "0.1.4", note = "Use `method()` instead.")]
     pub fn get_method(&self) -> &str {
@@ -383,6 +489,17 @@ pub enum NotificationFromClient {
     CustomNotification(serde_json::Value),
 }
 
+impl TryFrom<NotificationFromClient> for ClientNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromClient) -> result::Result<Self, Self::Error> {
+        if let NotificationFromClient::ClientNotification(client_notification) = value {
+            Ok(client_notification)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ClientNotification".to_string()))
+        }
+    }
+}
+
 impl NotificationFromClient {
     #[deprecated(since = "0.1.4", note = "Use `method()` instead.")]
     pub fn get_method(&self) -> &str {
@@ -473,6 +590,17 @@ pub enum ResultFromClient {
     CustomResult(serde_json::Value),
 }
 
+impl TryFrom<ResultFromClient> for ClientResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromClient) -> result::Result<Self, Self::Error> {
+        if let ResultFromClient::ClientResult(client_result) = value {
+            Ok(client_result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ClientResult".to_string()))
+        }
+    }
+}
+
 impl From<ClientResult> for ResultFromClient {
     fn from(value: ClientResult) -> Self {
         Self::ClientResult(value)
@@ -539,16 +667,110 @@ pub enum ServerMessage {
     Error(JsonrpcError),
 }
 
+impl ServerMessage {
+    /// Converts the current message into a `ServerJsonrpcResponse` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Response`. If so, it returns the
+    /// `ServerJsonrpcResponse` wrapped in a `Result::Ok`. If the message is not a `Response`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ServerJsonrpcResponse)` if the message is a valid `Response`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_response(self) -> std::result::Result<ServerJsonrpcResponse, JsonrpcErrorError> {
+        if let Self::Response(response) = self {
+            Ok(response)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Response,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `ServerJsonrpcRequest` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Request`. If so, it returns the
+    /// `ServerJsonrpcRequest` wrapped in a `Result::Ok`. If the message is not a `Request`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ServerJsonrpcRequest)` if the message is a valid `Request`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_request(self) -> std::result::Result<ServerJsonrpcRequest, JsonrpcErrorError> {
+        if let Self::Request(request) = self {
+            Ok(request)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Request,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `ServerJsonrpcNotification` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Notification`. If so, it returns the
+    /// `ServerJsonrpcNotification` wrapped in a `Result::Ok`. If the message is not a `Notification`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(ServerJsonrpcNotification)` if the message is a valid `Notification`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_notification(self) -> std::result::Result<ServerJsonrpcNotification, JsonrpcErrorError> {
+        if let Self::Notification(notification) = self {
+            Ok(notification)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Notification,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+
+    /// Converts the current message into a `JsonrpcError` if it's of the correct type.
+    ///
+    /// This function checks if the current message is of type `Error`. If so, it returns the
+    /// `JsonrpcError` wrapped in a `Result::Ok`. If the message is not a `Error`,
+    /// it returns an error with a descriptive message indicating the mismatch in expected message types.
+    ///
+    /// # Returns
+    /// - `Ok(JsonrpcError)` if the message is a valid `Error`.
+    /// - `Err(JsonrpcErrorError)` if the message type is invalid
+    pub fn as_error(self) -> std::result::Result<JsonrpcError, JsonrpcErrorError> {
+        if let Self::Error(error) = self {
+            Ok(error)
+        } else {
+            Err(JsonrpcErrorError::internal_error()
+                .with_message(format!(
+                    "Invalid message type, expected: \"{}\" received\"{}\"",
+                    MessageTypes::Error,
+                    self.message_type()
+                ))
+                )
+        }
+    }
+}
+
 impl RPCMessage for ServerMessage {
     // Retrieves the request ID associated with the message, if applicable
     fn request_id(&self) -> Option<&RequestId> {
         match self {
             // If the message is a request, return the associated request ID
-            ServerMessage::Request(client_jsonrpc_request) => Some(&client_jsonrpc_request.id),
+            ServerMessage::Request(server_jsonrpc_request) => Some(&server_jsonrpc_request.id),
             // Notifications do not have request IDs
             ServerMessage::Notification(_) => None,
             // If the message is a response, return the associated request ID
-            ServerMessage::Response(client_jsonrpc_response) => Some(&client_jsonrpc_response.id),
+            ServerMessage::Response(server_jsonrpc_response) => Some(&server_jsonrpc_response.id),
             // If the message is an error, return the associated request ID
             ServerMessage::Error(jsonrpc_error) => Some(&jsonrpc_error.id),
         }
@@ -557,11 +779,11 @@ impl RPCMessage for ServerMessage {
     fn jsonrpc(&self) -> &str {
         match self {
             // If the message is a request, return the associated request ID
-            ServerMessage::Request(client_jsonrpc_request) => client_jsonrpc_request.jsonrpc(),
+            ServerMessage::Request(server_jsonrpc_request) => server_jsonrpc_request.jsonrpc(),
             // Notifications do not have request IDs
             ServerMessage::Notification(notification) => notification.jsonrpc(),
             // If the message is a response, return the associated request ID
-            ServerMessage::Response(client_jsonrpc_response) => client_jsonrpc_response.jsonrpc(),
+            ServerMessage::Response(server_jsonrpc_response) => server_jsonrpc_response.jsonrpc(),
             // If the message is an error, return the associated request ID
             ServerMessage::Error(jsonrpc_error) => jsonrpc_error.jsonrpc(),
         }
@@ -680,6 +902,17 @@ pub enum RequestFromServer {
     CustomRequest(serde_json::Value),
 }
 
+impl TryFrom<RequestFromServer> for ServerRequest {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: RequestFromServer) -> result::Result<Self, Self::Error> {
+        if let RequestFromServer::ServerRequest(server_request) = value {
+            Ok(server_request)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ServerRequest".to_string()))
+        }
+    }
+}
+
 impl RequestFromServer {
     #[deprecated(since = "0.1.4", note = "Use `method()` instead.")]
     pub fn get_method(&self) -> &str {
@@ -783,6 +1016,17 @@ pub enum NotificationFromServer {
     CustomNotification(serde_json::Value),
 }
 
+impl TryFrom<NotificationFromServer> for ServerNotification {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: NotificationFromServer) -> result::Result<Self, Self::Error> {
+        if let NotificationFromServer::ServerNotification(server_notification) = value {
+            Ok(server_notification)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ServerNotification".to_string()))
+        }
+    }
+}
+
 impl NotificationFromServer {
     #[deprecated(since = "0.1.4", note = "Use `method()` instead.")]
     pub fn get_method(&self) -> &str {
@@ -871,6 +1115,17 @@ impl FromStr for ServerJsonrpcResponse {
 pub enum ResultFromServer {
     ServerResult(ServerResult),
     CustomResult(serde_json::Value),
+}
+
+impl TryFrom<ResultFromServer> for ServerResult {
+    type Error = JsonrpcErrorError;
+    fn try_from(value: ResultFromServer) -> result::Result<Self, Self::Error> {
+        if let ResultFromServer::ServerResult(server_result) = value {
+            Ok(server_result)
+        } else {
+            Err(JsonrpcErrorError::internal_error().with_message("Not a ServerResult".to_string()))
+        }
+    }
 }
 
 impl From<ServerResult> for ResultFromServer {


### PR DESCRIPTION
### 📌 Summary
Implemented the `TryFrom` trait for all MCP message variants to simplify type conversions when needed.
