### PR TITLE
feat: add SdkError codes and types

### DIFF
--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-02-22 12:06:03
+/// Generated at : 2025-02-22 12:34:28
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -2032,6 +2032,71 @@ impl From<ListRootsResult> for MessageFromClient {
         MessageFromClient::ResultFromClient(value.into())
     }
 }
+/// Enum representing SDK error codes.
+#[allow(non_camel_case_types)]
+pub enum SdkErrorCodes {
+    CONNECTION_CLOSED = -32000,
+    REQUEST_TIMEOUT = -32001,
+}
+impl core::fmt::Display for SdkErrorCodes {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SdkErrorCodes::CONNECTION_CLOSED => write!(f, "Connection closed"),
+            SdkErrorCodes::REQUEST_TIMEOUT => write!(f, "Request timeout"),
+        }
+    }
+}
+impl From<SdkErrorCodes> for i64 {
+    fn from(code: SdkErrorCodes) -> Self {
+        code as i64
+    }
+}
+#[derive(Debug)]
+pub struct SdkError {
+    ///The error type that occurred.
+    pub code: i64,
+    ///Additional information about the error.
+    pub data: ::std::option::Option<::serde_json::Value>,
+    ///A short description of the error.
+    pub message: ::std::string::String,
+}
+impl core::fmt::Display for SdkError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "MCP error {}: {}", self.code, self.message)
+    }
+}
+impl std::error::Error for SdkError {
+    fn description(&self) -> &str {
+        &self.message
+    }
+}
+impl SdkError {
+    pub fn new(
+        error_code: SdkErrorCodes,
+        message: ::std::string::String,
+        data: ::std::option::Option<::serde_json::Value>,
+    ) -> Self {
+        Self {
+            code: error_code.into(),
+            data,
+            message,
+        }
+    }
+    pub fn connection_closed() -> Self {
+        Self {
+            code: SdkErrorCodes::CONNECTION_CLOSED.into(),
+            data: None,
+            message: SdkErrorCodes::CONNECTION_CLOSED.to_string(),
+        }
+    }
+    pub fn request_timeout(timeout: u128) -> Self {
+        Self {
+            code: SdkErrorCodes::REQUEST_TIMEOUT.into(),
+            data: Some(json!({ "timeout" : timeout })),
+            message: SdkErrorCodes::REQUEST_TIMEOUT.to_string(),
+        }
+    }
+}
 /// Enum representing standard JSON-RPC error codes.
 #[allow(non_camel_case_types)]
 pub enum RpcErrorCodes {

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-02-22 12:06:03
+/// Generated at : 2025-02-22 12:34:29
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -2017,6 +2017,71 @@ impl From<ListRootsResult> for MessageFromClient {
         MessageFromClient::ResultFromClient(value.into())
     }
 }
+/// Enum representing SDK error codes.
+#[allow(non_camel_case_types)]
+pub enum SdkErrorCodes {
+    CONNECTION_CLOSED = -32000,
+    REQUEST_TIMEOUT = -32001,
+}
+impl core::fmt::Display for SdkErrorCodes {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SdkErrorCodes::CONNECTION_CLOSED => write!(f, "Connection closed"),
+            SdkErrorCodes::REQUEST_TIMEOUT => write!(f, "Request timeout"),
+        }
+    }
+}
+impl From<SdkErrorCodes> for i64 {
+    fn from(code: SdkErrorCodes) -> Self {
+        code as i64
+    }
+}
+#[derive(Debug)]
+pub struct SdkError {
+    ///The error type that occurred.
+    pub code: i64,
+    ///Additional information about the error.
+    pub data: ::std::option::Option<::serde_json::Value>,
+    ///A short description of the error.
+    pub message: ::std::string::String,
+}
+impl core::fmt::Display for SdkError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "MCP error {}: {}", self.code, self.message)
+    }
+}
+impl std::error::Error for SdkError {
+    fn description(&self) -> &str {
+        &self.message
+    }
+}
+impl SdkError {
+    pub fn new(
+        error_code: SdkErrorCodes,
+        message: ::std::string::String,
+        data: ::std::option::Option<::serde_json::Value>,
+    ) -> Self {
+        Self {
+            code: error_code.into(),
+            data,
+            message,
+        }
+    }
+    pub fn connection_closed() -> Self {
+        Self {
+            code: SdkErrorCodes::CONNECTION_CLOSED.into(),
+            data: None,
+            message: SdkErrorCodes::CONNECTION_CLOSED.to_string(),
+        }
+    }
+    pub fn request_timeout(timeout: u128) -> Self {
+        Self {
+            code: SdkErrorCodes::REQUEST_TIMEOUT.into(),
+            data: Some(json!({ "timeout" : timeout })),
+            message: SdkErrorCodes::REQUEST_TIMEOUT.to_string(),
+        }
+    }
+}
 /// Enum representing standard JSON-RPC error codes.
 #[allow(non_camel_case_types)]
 pub enum RpcErrorCodes {


### PR DESCRIPTION
### 📌 Summary
<!-- Provide a concise description of your changes. What problem does this PR solve? -->
Added `SdkErrorCodes` to `schema_utils`, including `ConnectionClosed` and `RequestTimeout`, along with the necessary error-related trait implementations and utility functions for creating and converting SDK errors.
