### PR TITLE
feat: introduce CallToolError

### DIFF
--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-02-22 14:26:53
+/// Generated at : 2025-02-28 17:52:11
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-02-22 14:26:53
+/// Generated at : 2025-02-28 17:52:11
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version


### PR DESCRIPTION
### 📌 Summary

Introduces a new error type in `schema_utils` that simplifies development by allowing any type of error to be returned in response to a `CallToolRequest` when the tool does not exist or fails for any reason.