### PR TITLE
fix: add missing MCPMessage trait implementation for MessageFromClient

### DIFF
--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-03-02 12:29:03
+/// Generated at : 2025-03-02 12:41:59
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -1327,6 +1327,33 @@ impl From<JsonrpcErrorError> for MessageFromClient {
     }
 }
 
+impl MCPMessage for MessageFromClient {
+    fn is_response(&self) -> bool {
+        matches!(self, MessageFromClient::ResultFromClient(_))
+    }
+
+    fn is_request(&self) -> bool {
+        matches!(self, MessageFromClient::RequestFromClient(_))
+    }
+
+    fn is_notification(&self) -> bool {
+        matches!(self, MessageFromClient::NotificationFromClient(_))
+    }
+
+    fn is_error(&self) -> bool {
+        matches!(self, MessageFromClient::Error(_))
+    }
+
+    fn message_type(&self) -> MessageTypes {
+        match self {
+            MessageFromClient::RequestFromClient(_) => MessageTypes::Request,
+            MessageFromClient::ResultFromClient(_) => MessageTypes::Response,
+            MessageFromClient::NotificationFromClient(_) => MessageTypes::Notification,
+            MessageFromClient::Error(_) => MessageTypes::Error,
+        }
+    }
+}
+
 impl FromMessage<MessageFromClient> for ClientMessage {
     fn from_message(
         message: MessageFromClient,

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-03-02 12:29:04
+/// Generated at : 2025-03-02 12:41:59
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -1327,6 +1327,33 @@ impl From<JsonrpcErrorError> for MessageFromClient {
     }
 }
 
+impl MCPMessage for MessageFromClient {
+    fn is_response(&self) -> bool {
+        matches!(self, MessageFromClient::ResultFromClient(_))
+    }
+
+    fn is_request(&self) -> bool {
+        matches!(self, MessageFromClient::RequestFromClient(_))
+    }
+
+    fn is_notification(&self) -> bool {
+        matches!(self, MessageFromClient::NotificationFromClient(_))
+    }
+
+    fn is_error(&self) -> bool {
+        matches!(self, MessageFromClient::Error(_))
+    }
+
+    fn message_type(&self) -> MessageTypes {
+        match self {
+            MessageFromClient::RequestFromClient(_) => MessageTypes::Request,
+            MessageFromClient::ResultFromClient(_) => MessageTypes::Response,
+            MessageFromClient::NotificationFromClient(_) => MessageTypes::Notification,
+            MessageFromClient::Error(_) => MessageTypes::Error,
+        }
+    }
+}
+
 impl FromMessage<MessageFromClient> for ClientMessage {
     fn from_message(
         message: MessageFromClient,


### PR DESCRIPTION
### 📌 Summary
The `MCPMessage` trait offers useful methods for messages, such as i`s_response()`,`is_request()`, `is_notification()`, `is_error()`, and `message_type()`.

However, the implementation of `MCPMessage` was missing for one of the eligible types, `MessageFromClient`, which created challenges when developing an MCP Client.

This PR adds the missing implementation for `MessageFromClient`.
