### PR TITLE
fix: custom result deserialization conflic with rust_mcp_schema::Result

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,8 @@ run_clippy = [
     "latest schema_utils",
     "--fix",
     "--",
+    "-A",
+    "deprecated",
     "-D",
     "warnings",
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,7 @@ run_clippy = [
     "--features",
     "latest schema_utils",
     "--fix",
+    "--allow-dirty",
     "--",
     "-A",
     "deprecated",

--- a/scripts/run_clippy.sh
+++ b/scripts/run_clippy.sh
@@ -11,7 +11,7 @@ COMMON_FEATURES_STR="${COMMON_FEATURES[*]}"
 
 for FEATURE in "${SCHEMA_VERSION_FEATURES[@]}"; do
     echo "🚀 Running Clippy with: --features \"$COMMON_FEATURES_STR $FEATURE\""
-    cargo clippy --all-targets --no-default-features --features "$COMMON_FEATURES_STR $FEATURE" -- -D warnings
+    cargo clippy --all-targets --no-default-features --features "$COMMON_FEATURES_STR $FEATURE" -- -A deprecated -D warnings
 
     # stop on failure
     if [ $? -ne 0 ]; then

--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -5,8 +5,8 @@
 /// modify or extend the implementations as needed, but please do so at your own risk.
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
-/// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-03-02 12:41:59
+/// Hash : 6828f3ef6300b25dd2aaff2a2e5e81188bdbd22e
+/// Generated at : 2025-03-08 08:33:48
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version
@@ -5155,7 +5155,7 @@ impl ::std::convert::From<Result> for ServerResult {
 ///      ],
 ///      "properties": {
 ///        "level": {
-///          "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/logging/message.",
+///          "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message.",
 ///          "$ref": "#/definitions/LoggingLevel"
 ///        }
 ///      }
@@ -5192,7 +5192,7 @@ impl SetLevelRequest {
 ///  ],
 ///  "properties": {
 ///    "level": {
-///      "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/logging/message.",
+///      "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message.",
 ///      "$ref": "#/definitions/LoggingLevel"
 ///    }
 ///  }
@@ -5201,7 +5201,7 @@ impl SetLevelRequest {
 /// </details>
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct SetLevelRequestParams {
-    ///The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/logging/message.
+    ///The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message.
     pub level: LoggingLevel,
 }
 ///Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -587,6 +587,7 @@ impl FromStr for ClientJsonrpcResponse {
 #[serde(untagged)]
 pub enum ResultFromClient {
     ClientResult(ClientResult),
+    #[deprecated(since = "0.1.8", note = "Use `ClientResult::Result` with extra attributes instead.")]
     CustomResult(serde_json::Value),
 }
 
@@ -1106,6 +1107,7 @@ impl FromStr for ServerJsonrpcResponse {
 #[serde(untagged)]
 pub enum ResultFromServer {
     ServerResult(ServerResult),
+    #[deprecated(since = "0.1.8", note = "Use `ServerResult::Result` with extra attributes instead.")]
     CustomResult(serde_json::Value),
 }
 
@@ -1142,13 +1144,7 @@ impl<'de> serde::Deserialize<'de> for ResultFromServer {
         let result = ServerResult::deserialize(&raw_value);
 
         match result {
-            Ok(server_result) => {
-                if matches!(server_result, ServerResult::Result(_)) {
-                    Ok(Self::CustomResult(raw_value))
-                } else {
-                    Ok(Self::ServerResult(server_result))
-                }
-            }
+            Ok(server_result) => Ok(Self::ServerResult(server_result)),
             Err(_) => Ok(Self::CustomResult(raw_value)),
         }
     }

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -5,8 +5,8 @@
 /// modify or extend the implementations as needed, but please do so at your own risk.
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
-/// Hash : bb1446ff1810a0df57989d78366d626d2c01b9d7
-/// Generated at : 2025-03-02 12:41:59
+/// Hash : 6828f3ef6300b25dd2aaff2a2e5e81188bdbd22e
+/// Generated at : 2025-03-08 08:33:48
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version
@@ -5289,7 +5289,7 @@ impl ::std::convert::From<Result> for ServerResult {
 ///      ],
 ///      "properties": {
 ///        "level": {
-///          "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/logging/message.",
+///          "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message.",
 ///          "$ref": "#/definitions/LoggingLevel"
 ///        }
 ///      }
@@ -5326,7 +5326,7 @@ impl SetLevelRequest {
 ///  ],
 ///  "properties": {
 ///    "level": {
-///      "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/logging/message.",
+///      "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message.",
 ///      "$ref": "#/definitions/LoggingLevel"
 ///    }
 ///  }
@@ -5335,7 +5335,7 @@ impl SetLevelRequest {
 /// </details>
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct SetLevelRequestParams {
-    ///The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/logging/message.
+    ///The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message.
     pub level: LoggingLevel,
 }
 ///Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -1142,9 +1142,7 @@ impl<'de> serde::Deserialize<'de> for ResultFromServer {
         let result = ServerResult::deserialize(&raw_value);
 
         match result {
-            Ok(server_result) => {
-               Ok(Self::ServerResult(server_result))
-            }
+            Ok(server_result) => Ok(Self::ServerResult(server_result)),
             Err(_) => Ok(Self::CustomResult(raw_value)),
         }
     }

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -1143,11 +1143,7 @@ impl<'de> serde::Deserialize<'de> for ResultFromServer {
 
         match result {
             Ok(server_result) => {
-                if matches!(server_result, ServerResult::Result(_)) {
-                    Ok(Self::CustomResult(raw_value))
-                } else {
-                    Ok(Self::ServerResult(server_result))
-                }
+               Ok(Self::ServerResult(server_result))
             }
             Err(_) => Ok(Self::CustomResult(raw_value)),
         }

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -222,7 +222,7 @@ mod test_deserialize {
     fn test_server_ping_result() {
         let message = get_message("res_ping");
         assert!(matches!(message, ServerMessage::Response(server_message)
-                if matches!(&server_message.result, ResultFromServer::CustomResult(_server_result))
+                if matches!(&server_message.result, ResultFromServer::ServerResult(_server_result))
         ));
     }
 

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -388,7 +388,7 @@ mod test_serialize {
     #[test]
     fn test_server_custom_result() {
         let custom_result: serde_json::Map<String, serde_json::Value> = json!({
-            "custom_key":"cutom_value",
+            "custom_key":"custom_value",
             "custom_number": 15.21
         })
         .as_object()

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -387,17 +387,29 @@ mod test_serialize {
 
     #[test]
     fn test_server_custom_result() {
+        let custom_result: serde_json::Map<String, serde_json::Value> = json!({
+            "custom_key":"cutom_value",
+            "custom_number": 15.21
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
         let message: ServerMessage = ServerMessage::Response(ServerJsonrpcResponse::new(
             RequestId::Integer(15),
-            ResultFromServer::CustomResult(json!({
-                "result":{},"jsonrpc":"2.0","id":15
+            ResultFromServer::ServerResult(ServerResult::Result(Result {
+                meta: None,
+                extra: Some(custom_result),
             })),
         ));
 
         let message: ServerMessage = re_serialize(message);
 
         assert!(matches!(message, ServerMessage::Response(server_message)
-                if matches!(&server_message.result, ResultFromServer::CustomResult(_))
+                if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
+                if matches!(server_result, ServerResult::Result(result)
+                if result.extra.is_some()
+            ))
         ));
     }
 


### PR DESCRIPTION
### 📌 Summary

The deserialize implementation for `ResultFromServer` was inconsistent with `ResultFromClient`, leading to ping results from various MCP servers being deserialized into a `CustomResult` instead of a `ServerResult`.

This issue arose because `rust_mcp_schema::Result` overlaps with `CustomResult`, as both can accept arbitrary attributes.

The deserialize implementation has been updated to correctly return the appropriate type. However, `CustomResult` will be deprecated in favor of `rust_mcp_schema::Result` to eliminate this conflict.
