### PR TITLE
fix: soft depricate CustomResult variants to supress warnings without breaking change

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 [YOUR NAME]
+Copyright (c) 2025 Rust MCP Stack (rust-mcp-schema)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy  
 of this software and associated documentation files (the "Software"), to deal  

--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : eb4abdf2bb91e0d5afd94510741eadd416982350
-/// Generated at : 2025-03-22 09:38:48
+/// Generated at : 2025-03-23 16:07:00
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -571,7 +571,7 @@ impl FromStr for ClientJsonrpcResponse {
 #[serde(untagged)]
 pub enum ResultFromClient {
     ClientResult(ClientResult),
-    #[deprecated(since = "0.1.8", note = "Use `ClientResult::Result` with extra attributes instead.")]
+    /// **Deprecated**: Use `ClientResult::Result` with extra attributes instead.
     CustomResult(serde_json::Value),
 }
 
@@ -1075,7 +1075,7 @@ impl FromStr for ServerJsonrpcResponse {
 #[serde(untagged)]
 pub enum ResultFromServer {
     ServerResult(ServerResult),
-    #[deprecated(since = "0.1.8", note = "Use `ServerResult::Result` with extra attributes instead.")]
+    /// **Deprecated**: Use `ServerResult::Result` with extra attributes instead.
     CustomResult(serde_json::Value),
 }
 

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6,7 +6,7 @@
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
 /// Hash : eb4abdf2bb91e0d5afd94510741eadd416982350
-/// Generated at : 2025-03-22 09:38:49
+/// Generated at : 2025-03-23 16:07:01
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -571,7 +571,7 @@ impl FromStr for ClientJsonrpcResponse {
 #[serde(untagged)]
 pub enum ResultFromClient {
     ClientResult(ClientResult),
-    #[deprecated(since = "0.1.8", note = "Use `ClientResult::Result` with extra attributes instead.")]
+    /// **Deprecated**: Use `ClientResult::Result` with extra attributes instead.
     CustomResult(serde_json::Value),
 }
 
@@ -1075,7 +1075,7 @@ impl FromStr for ServerJsonrpcResponse {
 #[serde(untagged)]
 pub enum ResultFromServer {
     ServerResult(ServerResult),
-    #[deprecated(since = "0.1.8", note = "Use `ServerResult::Result` with extra attributes instead.")]
+    /// **Deprecated**: Use `ServerResult::Result` with extra attributes instead.
     CustomResult(serde_json::Value),
 }
 


### PR DESCRIPTION
### 📌 Summary
Soft deprecate `CustomResult` variants to avoid triggering warnings while maintaining compatibility without a breaking change.


### ✨ Changes Made

- Soft deprecate `ResultFromClient::CustomResult` variants to avoid triggering warnings while maintaining compatibility without a breaking change.

- Soft deprecate `ResultFromServer::CustomResult` variants to avoid triggering warnings while maintaining compatibility without a breaking change.
- Generated latest version of schema
- updated a typo in LICENSE file
