### PR TITLE
feat!: add support for multiple active schema versions 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,12 @@ features = ["2025_03_26", "schema_utils"]
 [features]
 
 # defalt features
-default = ["2025_03_26", "schema_utils"] # Default features
+default = ["latest", "schema_utils"] # Default features
 
 # activates the latest MCP schema version, this will be updated once a new version of schema is published
 latest = ["2025_03_26"]
-
 # enabled mcp schema version 2025_03_26
-2025_03_26 = []
+2025_03_26 = ["latest"]
 # enabled mcp schema version 2024_11_05
 2024_11_05 = []
 # enabled draft mcp schema

--- a/README.md
+++ b/README.md
@@ -76,8 +76,14 @@ This repository provides all official released versions the schema , including d
 
 ### How to switch between different schema versions?
 
+By default, the latest version of the MCP Protocol schema is enabled.
+
 Each schema version has a corresponding Cargo feature that can be enabled in your project's Cargo.toml.
-By default, the version `2025_03_26` of the schema is active.
+
+Multiple schema versions may be enabled concurrently if needed. Non-default versions are available under explicitly named modules, for example:
+
+- rust_mcp_schema::mcp_2024_11_05
+- rust_mcp_schema::mcp_draft"
 
 Example: enable `2024_11_05` version of the shema:
 
@@ -85,21 +91,14 @@ Example: enable `2024_11_05` version of the shema:
 
 ```toml
 # Cargo.toml
-rust-mcp-schema = { version: 0.5.2 , features=["2024_11_05"] }
-```
-
-Example: enable `latest` version of the shema:
-
-```toml
-#Cargo.toml
-rust-mcp-schema = { version: 0.5.2 , features=["latest"] }
+rust-mcp-schema = { version: 0.5.2 , default-features = false, features=["2024_11_05"] }
 ```
 
 Example: enable `draft`` version of the shema (2024_11_05) :
 
 ```toml
 #Cargo.toml
-rust-mcp-schema = { version: 0.5.2 , features=["draft"] }
+rust-mcp-schema = { version: 0.5.2 , default-features = false, features=["draft"] }
 ```
 
 <!-- x-release-please-end -->

--- a/examples/mcp_client_handle_message.rs
+++ b/examples/mcp_client_handle_message.rs
@@ -1,5 +1,18 @@
+#[cfg(feature = "latest")]
 use rust_mcp_schema::schema_utils::*;
+#[cfg(feature = "latest")]
 use rust_mcp_schema::*;
+
+#[cfg(feature = "2024_11_05")]
+use rust_mcp_schema::mcp_2024_11_05::schema_utils::*;
+#[cfg(feature = "2024_11_05")]
+use rust_mcp_schema::mcp_2024_11_05::*;
+
+#[cfg(feature = "draft")]
+use rust_mcp_schema::mcp_draft::schema_utils::*;
+#[cfg(feature = "draft")]
+use rust_mcp_schema::mcp_draft::*;
+
 use std::str::FromStr;
 
 type AppError = RpcError;

--- a/examples/mcp_server_handle_message.rs
+++ b/examples/mcp_server_handle_message.rs
@@ -1,5 +1,18 @@
+#[cfg(feature = "latest")]
 use rust_mcp_schema::schema_utils::*;
+#[cfg(feature = "latest")]
 use rust_mcp_schema::*;
+
+#[cfg(feature = "2024_11_05")]
+use rust_mcp_schema::mcp_2024_11_05::schema_utils::*;
+#[cfg(feature = "2024_11_05")]
+use rust_mcp_schema::mcp_2024_11_05::*;
+
+#[cfg(feature = "draft")]
+use rust_mcp_schema::mcp_draft::schema_utils::*;
+#[cfg(feature = "draft")]
+use rust_mcp_schema::mcp_draft::*;
+
 use std::str::FromStr;
 
 type AppError = RpcError;

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # common features (always included in the tests)
-COMMON_FEATURES=("schema_utils")  
+COMMON_FEATURES=("schema_utils")
 
 # schema versions features (tested one at a time)
 SCHEMA_VERSION_FEATURES=("2025_03_26", "2024_11_05", "draft")
 
-# space-separated string 
+# space-separated string
 COMMON_FEATURES_STR="${COMMON_FEATURES[*]}"
 
 for FEATURE in "${SCHEMA_VERSION_FEATURES[@]}"; do
@@ -18,10 +18,6 @@ for FEATURE in "${SCHEMA_VERSION_FEATURES[@]}"; do
         echo "❌ Tests failed for: --features \"$COMMON_FEATURES_STR $FEATURE\""
         exit 1
     fi
-    
-    echo
-    echo "🚀 Running documentation tests with: --features \"$COMMON_FEATURES_STR $FEATURE\""
-    cargo test --doc --no-default-features --features "$COMMON_FEATURES_STR $FEATURE"
 
     # stop on failure
     if [ $? -ne 0 ]; then
@@ -29,5 +25,11 @@ for FEATURE in "${SCHEMA_VERSION_FEATURES[@]}"; do
         exit 1
     fi
 done
+
+# Get the first feature from the array
+FEATURE="${SCHEMA_VERSION_FEATURES[0]}"
+echo
+echo "🚀 Running documentation tests with: --features \"$COMMON_FEATURES_STR $FEATURE\""
+cargo test --doc --no-default-features --features "$COMMON_FEATURES_STR $FEATURE"
 
 echo "✅ All tests passed!"

--- a/src/generated_schema.rs
+++ b/src/generated_schema.rs
@@ -1,38 +1,65 @@
-/// Schema Version: 2024_11_05
-#[cfg(feature = "2024_11_05")]
-#[path = "generated_schema/2024_11_05/mcp_schema.rs"]
-mod mcp_schema;
+macro_rules! define_schema_version {
+    (
+        $feature:literal,
+        $mod_name:ident,
+        $schema_path:literal,
+        $utils_path:literal,
+        $schema_mod:ident,
+        $utils_mod:ident
+    ) => {
+        #[cfg(feature = $feature)]
+        #[path = $schema_path]
+        mod $schema_mod;
 
-#[cfg(feature = "2024_11_05")]
-pub use mcp_schema::*;
+        #[cfg(all(feature = "schema_utils", feature = $feature))]
+        #[path = $utils_path]
+        mod $utils_mod;
 
-#[cfg(all(feature = "schema_utils", feature = "2024_11_05"))]
-#[path = "generated_schema/2024_11_05/schema_utils.rs"]
-pub mod schema_utils;
+        #[cfg(feature = $feature)]
+        pub mod $mod_name {
+            pub use super::$schema_mod::*;
 
-/// Schema Version: 2025_03_26
+            #[cfg(feature = "schema_utils")]
+            pub mod schema_utils {
+                pub use super::super::$utils_mod::*;
+            }
+        }
+    };
+}
+
+/// Latest MCP Protocol 2025_03_26
 #[cfg(feature = "2025_03_26")]
-#[path = "generated_schema/2025_03_26/mcp_schema.rs"]
-mod mcp_schema;
+pub use mcp_2025_03_26::*;
 
 #[cfg(feature = "2025_03_26")]
-pub use mcp_schema::*;
+define_schema_version!(
+    "2025_03_26",
+    mcp_2025_03_26,
+    "generated_schema/2025_03_26/mcp_schema.rs",
+    "generated_schema/2025_03_26/schema_utils.rs",
+    __int_2025_03_26,
+    __int_utils_2025_03_26
+);
 
-#[cfg(all(feature = "schema_utils", feature = "2025_03_26"))]
-#[path = "generated_schema/2025_03_26/schema_utils.rs"]
-pub mod schema_utils;
+#[cfg(feature = "2024_11_05")]
+define_schema_version!(
+    "2024_11_05",
+    mcp_2024_11_05,
+    "generated_schema/2024_11_05/mcp_schema.rs",
+    "generated_schema/2024_11_05/schema_utils.rs",
+    __int_2024_11_05,
+    __int_utils_2024_11_05
+);
 
-/// Schema Version: draft
 #[cfg(feature = "draft")]
-#[path = "generated_schema/draft/mcp_schema.rs"]
-mod mcp_schema;
-
-#[cfg(feature = "draft")]
-pub use mcp_schema::*;
-
-#[cfg(all(feature = "schema_utils", feature = "draft"))]
-#[path = "generated_schema/draft/schema_utils.rs"]
-pub mod schema_utils;
+define_schema_version!(
+    "draft",
+    mcp_draft,
+    "generated_schema/draft/mcp_schema.rs",
+    "generated_schema/draft/schema_utils.rs",
+    __int_draft,
+    __int_utils_draft
+);
 
 #[path = "generated_schema/protocol_version.rs"]
 mod protocol_version;

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -1,4 +1,4 @@
-use crate::generated_schema::*;
+use crate::generated_schema::mcp_2024_11_05::*;
 use serde::ser::SerializeStruct;
 use serde_json::{json, Value};
 use std::hash::{Hash, Hasher};

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -1,4 +1,4 @@
-use crate::generated_schema::*;
+use crate::generated_schema::mcp_draft::*;
 use serde::ser::SerializeStruct;
 use serde_json::{json, Value};
 use std::hash::{Hash, Hasher};

--- a/src/rust-mcp-schema.rs
+++ b/src/rust-mcp-schema.rs
@@ -1,7 +1,4 @@
 /// modules
 mod generated_schema;
 
-/// re-exports
-#[cfg(feature = "schema_utils")]
-pub use generated_schema::schema_utils;
 pub use generated_schema::*;

--- a/tests/2024_11_05_exclusive.rs
+++ b/tests/2024_11_05_exclusive.rs
@@ -4,8 +4,8 @@ pub mod common;
 
 #[cfg(feature = "2024_11_05")]
 mod test_2024_11_05_exclusive {
-    use rust_mcp_schema::schema_utils::*;
-    use rust_mcp_schema::*;
+    use rust_mcp_schema::mcp_2024_11_05::schema_utils::*;
+    use rust_mcp_schema::mcp_2024_11_05::*;
 
     use super::common::{get_message, re_serialize};
 
@@ -73,7 +73,7 @@ mod test_2024_11_05_exclusive {
 
     #[test]
     fn test_server_list_resource_templates_result_sample() {
-        let message = get_message("res_template_list");
+        let message = get_message("res_template_list", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
                 if matches!(server_result, ServerResult::ListResourceTemplatesResult(_)))
@@ -82,7 +82,7 @@ mod test_2024_11_05_exclusive {
 
     #[test]
     fn test_client_list_resource_templates_request_sample() {
-        let message = get_message("req_template_list");
+        let message = get_message("req_template_list", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::ListResourceTemplatesRequest(_)))

--- a/tests/common/common.rs
+++ b/tests/common/common.rs
@@ -1,4 +1,3 @@
-use rust_mcp_schema::LATEST_PROTOCOL_VERSION;
 use serde_json::Value;
 use std::str::FromStr;
 use std::sync::OnceLock;
@@ -58,11 +57,11 @@ where
 }
 
 /// get a test message payload from the sample_mcp_messages.json by key
-pub fn get_message<T>(test_payload_key: &str) -> T
+pub fn get_message<T>(test_payload_key: &str, version: &str) -> T
 where
     T: FromStr + for<'de> serde::Deserialize<'de>,
     <T as FromStr>::Err: std::fmt::Debug,
 {
-    let message_str = get_test_payload(test_payload_key).replace("PROTOCOL_VERSION", LATEST_PROTOCOL_VERSION);
+    let message_str = get_test_payload(test_payload_key).replace("PROTOCOL_VERSION", version);
     T::from_str(&message_str).unwrap()
 }

--- a/tests/miscellaneous.rs
+++ b/tests/miscellaneous.rs
@@ -2,6 +2,11 @@
 pub mod common;
 
 mod miscellaneous_tests {
+    #[cfg(feature = "2024_11_05")]
+    use rust_mcp_schema::mcp_2024_11_05::schema_utils::*;
+    #[cfg(feature = "draft")]
+    use rust_mcp_schema::mcp_draft::schema_utils::*;
+    #[cfg(feature = "latest")]
     use rust_mcp_schema::schema_utils::*;
 
     #[test]

--- a/tests/test_deserialize.rs
+++ b/tests/test_deserialize.rs
@@ -2,7 +2,18 @@
 pub mod common;
 
 mod test_deserialize {
+    #[cfg(feature = "2024_11_05")]
+    use rust_mcp_schema::mcp_2024_11_05::schema_utils::*;
+    #[cfg(feature = "draft")]
+    use rust_mcp_schema::mcp_draft::schema_utils::*;
+    #[cfg(feature = "latest")]
     use rust_mcp_schema::schema_utils::*;
+
+    #[cfg(feature = "2024_11_05")]
+    use rust_mcp_schema::mcp_2024_11_05::*;
+    #[cfg(feature = "draft")]
+    use rust_mcp_schema::mcp_draft::*;
+    #[cfg(feature = "latest")]
     use rust_mcp_schema::*;
 
     use super::common::get_message;
@@ -10,7 +21,7 @@ mod test_deserialize {
     /* ---------------------- CLIENT REQUESTS ---------------------- */
     #[test]
     fn test_client_initialize_request() {
-        let message = get_message("req_initialize");
+        let message = get_message("req_initialize", LATEST_PROTOCOL_VERSION);
         assert!(matches!(&message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::InitializeRequest(_)))
@@ -38,7 +49,7 @@ mod test_deserialize {
 
     #[test]
     fn test_client_list_resources_request() {
-        let message = get_message("req_resource_list");
+        let message = get_message("req_resource_list", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::ListResourcesRequest(_)))
@@ -47,7 +58,7 @@ mod test_deserialize {
 
     #[test]
     fn test_client_read_resource_request() {
-        let message = get_message("req_resource_read");
+        let message = get_message("req_resource_read", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::ReadResourceRequest(_)))
@@ -56,7 +67,7 @@ mod test_deserialize {
 
     #[test]
     fn test_client_list_prompts_request() {
-        let message = get_message("req_prompts_list");
+        let message = get_message("req_prompts_list", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::ListPromptsRequest(_)))
@@ -65,13 +76,13 @@ mod test_deserialize {
 
     #[test]
     fn test_client_get_prompt_request() {
-        let message = get_message("req_prompts_get_1");
+        let message = get_message("req_prompts_get_1", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::GetPromptRequest(_)))
         ));
 
-        let message = get_message("req_prompts_get_2");
+        let message = get_message("req_prompts_get_2", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::GetPromptRequest(_)))
@@ -80,7 +91,7 @@ mod test_deserialize {
 
     #[test]
     fn test_client_list_tools_request() {
-        let message = get_message("req_tools_list");
+        let message = get_message("req_tools_list", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::ListToolsRequest(_)))
@@ -89,26 +100,26 @@ mod test_deserialize {
 
     #[test]
     fn test_client_call_tool_request() {
-        let message = get_message("req_tools_call_1");
+        let message = get_message("req_tools_call_1", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::CallToolRequest(_)))
         ));
 
-        let message = get_message("req_tools_call_2");
+        let message = get_message("req_tools_call_2", LATEST_PROTOCOL_VERSION);
 
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::CallToolRequest(_)))
         ));
 
-        let message = get_message("req_tools_call_3");
+        let message = get_message("req_tools_call_3", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::CallToolRequest(_)))
         ));
 
-        let message = get_message("req_tools_call_4");
+        let message = get_message("req_tools_call_4", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::CallToolRequest(_)))
@@ -117,7 +128,7 @@ mod test_deserialize {
 
     #[test]
     fn test_client_ping_request() {
-        let message = get_message("req_ping");
+        let message = get_message("req_ping", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Request(client_message)
                 if matches!(&client_message.request, RequestFromClient::ClientRequest(client_request)
                 if matches!(client_request, ClientRequest::PingRequest(_)))
@@ -127,7 +138,7 @@ mod test_deserialize {
     /* ---------------------- CLIENT RESPONSES ---------------------- */
     #[test]
     fn test_list_tools_result() {
-        let message = get_message("res_sampling_create_message_2");
+        let message = get_message("res_sampling_create_message_2", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Response(client_message)
                 if matches!(&client_message.result, ResultFromClient::ClientResult(client_result)
                         if matches!( client_result, ClientResult::CreateMessageResult(_))
@@ -138,7 +149,7 @@ mod test_deserialize {
 
     #[test]
     fn test_server_initialize_result() {
-        let message = get_message("res_initialize");
+        let message = get_message("res_initialize", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
                 if matches!(server_result, ServerResult::InitializeResult(_)))
@@ -147,7 +158,7 @@ mod test_deserialize {
 
     #[test]
     fn test_server_list_resources_result() {
-        let message = get_message("res_resource_list");
+        let message = get_message("res_resource_list", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
                 if matches!(server_result, ServerResult::ListResourcesResult(_)))
@@ -156,7 +167,7 @@ mod test_deserialize {
 
     #[test]
     fn test_server_read_resource_result() {
-        let message = get_message("res_resource_read");
+        let message = get_message("res_resource_read", LATEST_PROTOCOL_VERSION);
 
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
@@ -166,7 +177,7 @@ mod test_deserialize {
 
     #[test]
     fn test_server_list_prompts_result() {
-        let message = get_message("res_prompts_list");
+        let message = get_message("res_prompts_list", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
                 if matches!(server_result, ServerResult::ListPromptsResult(_)))
@@ -175,13 +186,13 @@ mod test_deserialize {
 
     #[test]
     fn test_server_get_prompt_result() {
-        let message = get_message("res_prompts_get_1");
+        let message = get_message("res_prompts_get_1", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
                 if matches!(server_result, ServerResult::GetPromptResult(_)))
         ));
 
-        let message = get_message("res_prompts_get_2");
+        let message = get_message("res_prompts_get_2", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
                 if matches!(server_result, ServerResult::GetPromptResult(_)))
@@ -190,7 +201,7 @@ mod test_deserialize {
 
     #[test]
     fn test_server_list_tools_result() {
-        let message = get_message("res_tools_list");
+        let message = get_message("res_tools_list", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
                 if matches!(server_result, ServerResult::ListToolsResult(_)))
@@ -201,19 +212,19 @@ mod test_deserialize {
     #[cfg(any(feature = "2025_03_26", feature = "2024_11_05"))]
     #[test]
     fn test_server_call_tool_result() {
-        let message = get_message("res_tools_call_1");
+        let message = get_message("res_tools_call_1", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
                 if matches!(server_result, ServerResult::CallToolResult(_)))
         ));
 
-        let message = get_message("res_tools_call_2");
+        let message = get_message("res_tools_call_2", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
                 if matches!(server_result, ServerResult::CallToolResult(_)))
         ));
 
-        let message = get_message("res_tools_call_4");
+        let message = get_message("res_tools_call_4", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(server_result)
                 if matches!(server_result, ServerResult::CallToolResult(_)))
@@ -222,7 +233,7 @@ mod test_deserialize {
 
     #[test]
     fn test_server_ping_result() {
-        let message = get_message("res_ping");
+        let message = get_message("res_ping", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Response(server_message)
                 if matches!(&server_message.result, ResultFromServer::ServerResult(_server_result))
         ));
@@ -233,21 +244,21 @@ mod test_deserialize {
     #[test]
     fn test_client_notifications() {
         //ClientInitializedNotification
-        let message = get_message("ntf_initialized");
+        let message = get_message("ntf_initialized", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Notification(client_message)
                 if matches!(&client_message.notification,NotificationFromClient::ClientNotification(client_notification)
                 if matches!( client_notification, ClientNotification::InitializedNotification(_)))
         ));
 
         //ClientRootsListChangedNotification
-        let message = get_message("ntf_root_list_changed");
+        let message = get_message("ntf_root_list_changed", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Notification(client_message)
                 if matches!(&client_message.notification,NotificationFromClient::ClientNotification(client_notification)
                 if matches!( client_notification, ClientNotification::RootsListChangedNotification(_)))
         ));
 
         //ClientCancelledNotification
-        let message = get_message("ntf_cancelled");
+        let message = get_message("ntf_cancelled", LATEST_PROTOCOL_VERSION);
 
         assert!(matches!(message, ClientMessage::Notification(client_message)
                 if matches!(&client_message.notification,NotificationFromClient::ClientNotification(client_notification)
@@ -259,13 +270,13 @@ mod test_deserialize {
     #[test]
     fn test_server_requests() {
         //ServerCreateMessageRequest
-        let message = get_message("req_sampling_create_message_1");
+        let message = get_message("req_sampling_create_message_1", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Request(server_message)
                 if matches!(&server_message.request,RequestFromServer::ServerRequest(server_request)
                 if matches!( server_request, ServerRequest::CreateMessageRequest(_)))
         ));
 
-        let message = get_message("req_sampling_create_message_2");
+        let message = get_message("req_sampling_create_message_2", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Request(server_message)
                 if matches!(&server_message.request,RequestFromServer::ServerRequest(server_request)
                 if matches!( server_request, ServerRequest::CreateMessageRequest(_)))
@@ -276,10 +287,10 @@ mod test_deserialize {
 
     #[test]
     fn test_errors() {
-        let message: ClientMessage = get_message("err_sampling_rejected");
+        let message: ClientMessage = get_message("err_sampling_rejected", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ClientMessage::Error(_)));
 
-        let message: ServerMessage = get_message("err_sampling_rejected");
+        let message: ServerMessage = get_message("err_sampling_rejected", LATEST_PROTOCOL_VERSION);
         assert!(matches!(message, ServerMessage::Error(_)));
     }
 }

--- a/tests/test_serialize.rs
+++ b/tests/test_serialize.rs
@@ -5,8 +5,20 @@ mod test_serialize {
     use std::str::FromStr;
     use std::vec;
 
+    #[cfg(feature = "2024_11_05")]
+    use rust_mcp_schema::mcp_2024_11_05::schema_utils::*;
+    #[cfg(feature = "2024_11_05")]
+    use rust_mcp_schema::mcp_2024_11_05::*;
+    #[cfg(feature = "draft")]
+    use rust_mcp_schema::mcp_draft::schema_utils::*;
+    #[cfg(feature = "draft")]
+    use rust_mcp_schema::mcp_draft::*;
+
+    #[cfg(feature = "latest")]
     use rust_mcp_schema::schema_utils::*;
+    #[cfg(feature = "latest")]
     use rust_mcp_schema::*;
+
     use serde_json::json;
 
     use super::common::re_serialize;


### PR DESCRIPTION

### 📌 Summary
This PR introduces support for enabling multiple MCP Protocol schema versions concurrently. While one version is designated as the default, additional versions can be activated via feature flags and accessed through clearly named modules.


### ✨ Changes Made

- Introduced versioned internal module names to avoid conflicts
- Non-default schemas are now accessible via modules such as:
  - `rust_mcp_schema::mcp_2024_11_05`
  - `rust_mcp_schema::mcp_draft`


### 💡 Additional Notes

- The default schema version remains enabled by default.
