### PR TITLE
feat: implement new utility functions for CallToolResult and TextContent

### DIFF
--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -5,8 +5,8 @@
 /// modify or extend the implementations as needed, but please do so at your own risk.
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
-/// Hash : 169021c2e1332eb9197a6f47fb6ec30e0a70b1d0
-/// Generated at : 2025-06-28 14:42:12
+/// Hash : 1cfdf1e7a8aa5065b7e3cb3e35e653df9542e0de
+/// Generated at : 2025-07-01 14:46:39
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2024_11_05/schema_utils.rs
+++ b/src/generated_schema/2024_11_05/schema_utils.rs
@@ -1444,6 +1444,12 @@ impl CallToolRequest {
     }
 }
 
+impl<T: Into<String>> From<T> for TextContent {
+    fn from(value: T) -> Self {
+        TextContent::new(value.into(), None)
+    }
+}
+
 #[deprecated(since = "0.4.0", note = "This trait was renamed to RpcMessage. Use RpcMessage instead.")]
 pub type RPCMessage = ();
 #[deprecated(since = "0.4.0", note = "This trait was renamed to McpMessage. Use McpMessage instead.")]

--- a/src/generated_schema/2025_03_26/mcp_schema.rs
+++ b/src/generated_schema/2025_03_26/mcp_schema.rs
@@ -5,8 +5,8 @@
 /// modify or extend the implementations as needed, but please do so at your own risk.
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
-/// Hash : 169021c2e1332eb9197a6f47fb6ec30e0a70b1d0
-/// Generated at : 2025-06-28 14:42:13
+/// Hash : 1cfdf1e7a8aa5065b7e3cb3e35e653df9542e0de
+/// Generated at : 2025-07-01 14:46:41
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2025_03_26/schema_utils.rs
+++ b/src/generated_schema/2025_03_26/schema_utils.rs
@@ -1444,6 +1444,12 @@ impl CallToolRequest {
     }
 }
 
+impl<T: Into<String>> From<T> for TextContent {
+    fn from(value: T) -> Self {
+        TextContent::new(value.into(), None)
+    }
+}
+
 #[deprecated(since = "0.4.0", note = "This trait was renamed to RpcMessage. Use RpcMessage instead.")]
 pub type RPCMessage = ();
 #[deprecated(since = "0.4.0", note = "This trait was renamed to McpMessage. Use McpMessage instead.")]

--- a/src/generated_schema/2025_06_18/mcp_schema.rs
+++ b/src/generated_schema/2025_06_18/mcp_schema.rs
@@ -5,8 +5,8 @@
 /// modify or extend the implementations as needed, but please do so at your own risk.
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
-/// Hash : 169021c2e1332eb9197a6f47fb6ec30e0a70b1d0
-/// Generated at : 2025-06-28 14:42:13
+/// Hash : 1cfdf1e7a8aa5065b7e3cb3e35e653df9542e0de
+/// Generated at : 2025-07-01 14:46:41
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/2025_06_18/schema_utils.rs
+++ b/src/generated_schema/2025_06_18/schema_utils.rs
@@ -1410,6 +1410,19 @@ impl From<CallToolError> for RpcError {
     }
 }
 
+/// Conversion of `CallToolError` into a `CallToolResult` with an error.
+impl From<CallToolError> for CallToolResult {
+    fn from(value: CallToolError) -> Self {
+        // Convert `CallToolError` to a `CallToolResult`
+        CallToolResult {
+            content: vec![TextContent::new(value.to_string(), None, None).into()],
+            is_error: Some(true),
+            meta: None,
+            structured_content: None,
+        }
+    }
+}
+
 // Implement `Display` for `CallToolError` to provide a user-friendly error message.
 impl core::fmt::Display for CallToolError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -1434,6 +1447,12 @@ impl CallToolRequest {
     /// A reference to the string containing the tool's name.
     pub fn tool_name(&self) -> &str {
         &self.params.name
+    }
+}
+
+impl<T: Into<String>> From<T> for TextContent {
+    fn from(value: T) -> Self {
+        TextContent::new(value.into(), None, None)
     }
 }
 
@@ -3768,6 +3787,70 @@ impl ContentBlock {
                 "EmbeddedResource"
             ))),
         }
+    }
+}
+impl CallToolResult {
+    pub fn text_content(content: Vec<TextContent>) -> Self {
+        Self {
+            content: content.into_iter().map(Into::into).collect(),
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        }
+    }
+    pub fn image_content(content: Vec<ImageContent>) -> Self {
+        Self {
+            content: content.into_iter().map(Into::into).collect(),
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        }
+    }
+    pub fn audio_content(content: Vec<AudioContent>) -> Self {
+        Self {
+            content: content.into_iter().map(Into::into).collect(),
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        }
+    }
+    pub fn resource_link(content: Vec<ResourceLink>) -> Self {
+        Self {
+            content: content.into_iter().map(Into::into).collect(),
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        }
+    }
+    pub fn embedded_resource(content: Vec<EmbeddedResource>) -> Self {
+        Self {
+            content: content.into_iter().map(Into::into).collect(),
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        }
+    }
+    /// Create a `CallToolResult` with an error, containing an error message in the content
+    pub fn with_error(error: CallToolError) -> Self {
+        Self {
+            content: vec![ContentBlock::TextContent(TextContent::new(error.to_string(), None, None))],
+            is_error: Some(true),
+            meta: None,
+            structured_content: None,
+        }
+    }
+    /// Assigns metadata to the CallToolResult, enabling the inclusion of extra context or details.
+    pub fn with_meta(mut self, meta: Option<serde_json::Map<String, Value>>) -> Self {
+        self.meta = meta;
+        self
+    }
+    /// Assigns structured_content to the CallToolResult
+    pub fn with_structured_content(
+        mut self,
+        structured_content: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
+    ) -> Self {
+        self.structured_content = Some(structured_content);
+        self
     }
 }
 /// END AUTO GENERATED

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -5,8 +5,8 @@
 /// modify or extend the implementations as needed, but please do so at your own risk.
 ///
 /// Generated from : <https://github.com/modelcontextprotocol/specification.git>
-/// Hash : 169021c2e1332eb9197a6f47fb6ec30e0a70b1d0
-/// Generated at : 2025-06-28 14:42:13
+/// Hash : 1cfdf1e7a8aa5065b7e3cb3e35e653df9542e0de
+/// Generated at : 2025-07-01 14:46:41
 /// ----------------------------------------------------------------------------
 ///
 /// MCP Protocol Version

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -1411,6 +1411,19 @@ impl From<CallToolError> for RpcError {
     }
 }
 
+/// Conversion of `CallToolError` into a `CallToolResult` with an error.
+impl From<CallToolError> for CallToolResult {
+    fn from(value: CallToolError) -> Self {
+        // Convert `CallToolError` to a `CallToolResult`
+        CallToolResult {
+            content: vec![TextContent::new(value.to_string(), None, None).into()],
+            is_error: Some(true),
+            meta: None,
+            structured_content: None,
+        }
+    }
+}
+
 // Implement `Display` for `CallToolError` to provide a user-friendly error message.
 impl core::fmt::Display for CallToolError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -1435,6 +1448,12 @@ impl CallToolRequest {
     /// A reference to the string containing the tool's name.
     pub fn tool_name(&self) -> &str {
         &self.params.name
+    }
+}
+
+impl<T: Into<String>> From<T> for TextContent {
+    fn from(value: T) -> Self {
+        TextContent::new(value.into(), None, None)
     }
 }
 
@@ -3769,6 +3788,70 @@ impl ContentBlock {
                 "EmbeddedResource"
             ))),
         }
+    }
+}
+impl CallToolResult {
+    pub fn text_content(content: Vec<TextContent>) -> Self {
+        Self {
+            content: content.into_iter().map(Into::into).collect(),
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        }
+    }
+    pub fn image_content(content: Vec<ImageContent>) -> Self {
+        Self {
+            content: content.into_iter().map(Into::into).collect(),
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        }
+    }
+    pub fn audio_content(content: Vec<AudioContent>) -> Self {
+        Self {
+            content: content.into_iter().map(Into::into).collect(),
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        }
+    }
+    pub fn resource_link(content: Vec<ResourceLink>) -> Self {
+        Self {
+            content: content.into_iter().map(Into::into).collect(),
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        }
+    }
+    pub fn embedded_resource(content: Vec<EmbeddedResource>) -> Self {
+        Self {
+            content: content.into_iter().map(Into::into).collect(),
+            is_error: None,
+            meta: None,
+            structured_content: None,
+        }
+    }
+    /// Create a `CallToolResult` with an error, containing an error message in the content
+    pub fn with_error(error: CallToolError) -> Self {
+        Self {
+            content: vec![ContentBlock::TextContent(TextContent::new(error.to_string(), None, None))],
+            is_error: Some(true),
+            meta: None,
+            structured_content: None,
+        }
+    }
+    /// Assigns metadata to the CallToolResult, enabling the inclusion of extra context or details.
+    pub fn with_meta(mut self, meta: Option<serde_json::Map<String, Value>>) -> Self {
+        self.meta = meta;
+        self
+    }
+    /// Assigns structured_content to the CallToolResult
+    pub fn with_structured_content(
+        mut self,
+        structured_content: ::serde_json::Map<::std::string::String, ::serde_json::Value>,
+    ) -> Self {
+        self.structured_content = Some(structured_content);
+        self
     }
 }
 /// END AUTO GENERATED


### PR DESCRIPTION
### 📌 Summary

This PR introduces a set of convenience constructor methods for the CallToolResult struct to simplify the creation of results with various content types. It also supports builder-style methods for attaching metadata and structured content.

This functionality was already available in previous schema versions and is now supported in the `2025_06_18` and `draft `versions as well, with a slightly updated function signature.

example:
```rs
let res_link = CallToolResult::resource_link(vec![ link1, link2  ]);

let text_result = CallToolResult::text_content(vec![ TextContent::from(goodbye_message) ])

```
