### PR TITLE
feat: support validation for method fields in `*Request`

### DIFF
--- a/src/generated_schema/2025_06_18/mcp_schema.rs
+++ b/src/generated_schema/2025_06_18/mcp_schema.rs
@@ -1312,6 +1312,8 @@ impl ::std::convert::From<EmbeddedResource> for ContentBlock {
 /// </details>
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct CreateMessageRequest {
+    // This field requires custom deserialization for validation.
+    #[serde(deserialize_with = "server_request_method_validation::deserialize_CreateMessageRequest_method")]
     method: ::std::string::String,
     pub params: CreateMessageRequestParams,
 }
@@ -1625,6 +1627,8 @@ pub struct Cursor(pub ::std::string::String);
 /// </details>
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct ElicitRequest {
+    // This field requires custom deserialization for validation.
+    #[serde(deserialize_with = "server_request_method_validation::deserialize_ElicitRequest_method")]
     method: ::std::string::String,
     pub params: ElicitRequestParams,
 }
@@ -3302,6 +3306,8 @@ structure or access specific locations that the client has permission to read fr
 /// </details>
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct ListRootsRequest {
+    // This field requires custom deserialization for validation.
+    #[serde(deserialize_with = "server_request_method_validation::deserialize_ListRootsRequest_method")]
     method: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub params: ::std::option::Option<ListRootsRequestParams>,
@@ -4040,6 +4046,8 @@ pub struct PaginatedResult {
 /// </details>
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct PingRequest {
+    // This field requires custom deserialization for validation.
+    #[serde(deserialize_with = "server_request_method_validation::deserialize_PingRequest_method")]
     method: ::std::string::String,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub params: ::std::option::Option<PingRequestParams>,
@@ -7167,5 +7175,111 @@ impl ServerNotification {
         }
     }
 }
+
+// Custom module for deserialization function to prevent name conflicts.
+mod server_request_method_validation{
+
+    // Custom deserialization function, following the `deserialize_#StructName_#FieldName` format.
+    #[allow(non_snake_case)]
+    pub(super) fn deserialize_PingRequest_method<'de, D>(
+        deserializer: D,
+    ) -> std::result::Result<String, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let value = serde::Deserialize::deserialize(deserializer)?;
+        // The expected constant value.
+        let expected = "ping";
+
+        // Validate the deserialized value.
+        if value == expected {
+            Ok(value)
+        } else {
+            // The error message with format
+            // "Expected field `#FieldName` in struct `#StructName` as const value '{}', but got '{}'"
+            Err(serde::de::Error::custom(format!(
+                "Expected field `method` in struct `PingRequest` as const value '{}', but got '{}'",
+                expected, value
+            )))
+        }
+    }
+
+    // Custom deserialization function, following the `deserialize_#StructName_#FieldName` format.
+    #[allow(non_snake_case)]
+    pub(super) fn deserialize_CreateMessageRequest_method<'de, D>(
+        deserializer: D,
+    ) -> std::result::Result<String, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let value = serde::Deserialize::deserialize(deserializer)?;
+        // The expected constant value.
+        let expected = "sampling/createMessage";
+
+        // Validate the deserialized value.
+        if value == expected {
+            Ok(value)
+        } else {
+            // The error message with format
+            // "Expected field `#FieldName` in struct `#StructName` as const value '{}', but got '{}'"
+            Err(serde::de::Error::custom(format!(
+                "Expected field `method` in struct `CreateMessageRequest` as const value '{}', but got '{}'",
+                expected, value
+            )))
+        }
+    }
+
+    // Custom deserialization function, following the `deserialize_#StructName_#FieldName` format.
+    #[allow(non_snake_case)]
+    pub(super) fn deserialize_ListRootsRequest_method<'de, D>(
+        deserializer: D,
+    ) -> std::result::Result<String, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let value = serde::Deserialize::deserialize(deserializer)?;
+        // The expected constant value.
+        let expected = "roots/list";
+
+        // Validate the deserialized value.
+        if value == expected {
+            Ok(value)
+        } else {
+            // The error message with format
+            // "Expected field `#FieldName` in struct `#StructName` as const value '{}', but got '{}'"
+            Err(serde::de::Error::custom(format!(
+                "Expected field `method` in struct `ListRootsRequest` as const value '{}', but got '{}'",
+                expected, value
+            )))
+        }
+    }
+
+    // Custom deserialization function, following the `deserialize_#StructName_#FieldName` format.
+    #[allow(non_snake_case)]
+    pub(super) fn deserialize_ElicitRequest_method<'de, D>(
+        deserializer: D,
+    ) -> std::result::Result<String, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        let value = serde::Deserialize::deserialize(deserializer)?;
+        // The expected constant value.
+        let expected = "elicitation/create";
+
+        // Validate the deserialized value.
+        if value == expected {
+            Ok(value)
+        } else {
+            // The error message with format
+            // "Expected field `#FieldName` in struct `#StructName` as const value '{}', but got '{}'"
+            Err(serde::de::Error::custom(format!(
+                "Expected field `method` in struct `ElicitRequest` as const value '{}', but got '{}'",
+                expected, value
+            )))
+        }
+    }
+
+}
+
 #[deprecated(since = "0.3.0", note = "Use `RpcError` instead.")]
 pub type JsonrpcErrorError = RpcError;

--- a/src/generated_schema/2025_06_18/schema_utils.rs
+++ b/src/generated_schema/2025_06_18/schema_utils.rs
@@ -3922,5 +3922,12 @@ mod tests {
         // default
         let result = detect_message_type(&json!({}));
         assert!(matches!(result, MessageTypes::Request));
+
+        // assert method type validation
+        let should_err:std::result::Result<PingRequest,_> = serde_json::from_value(json!({
+            "method":"wrong_method",
+            "params":null
+        }));
+        assert!(should_err.is_err());
     }
 }


### PR DESCRIPTION
**Closes:** #75

### The Problem

As identified in issue #75, the individual `*Request` structs (e.g., `PingRequest`, `ListResourcesRequest`) do not currently validate that their `method` field matches the constant value defined in the JSON schema. This creates ambiguity. For example, a JSON payload like:

```json
{
  "method": "wrong/method",
  "params": { /* ... valid params for ListResourcesRequest ... */ }
}
```

could be incorrectly deserialized as a `ListResourcesRequest`. The deserialization process should fail fast if the `method` name is incorrect for the target struct.

### The Solution

This pull request proposes a robust pattern to validate the `method` field by leveraging Serde's `#[serde(deserialize_with = "...")]`:

1.  Deserializes the incoming value as a string.
2.  Compares it against the expected constant value for that specific request type.

### Note for Maintainers

**⚠️ This pull request should NOT be merged directly. It serves as a working example for the code generator.**