### PR TITLE
Use BTreeMap instead of HashMap for deterministic serialization

### DIFF
--- a/src/generated_schema/2024_11_05/mcp_schema.rs
+++ b/src/generated_schema/2024_11_05/mcp_schema.rs
@@ -453,7 +453,7 @@ pub struct ClientCapabilities {
     ///Experimental, non-standard capabilities that the client supports.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub experimental: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub roots: ::std::option::Option<ClientCapabilitiesRoots>,
@@ -1551,7 +1551,7 @@ impl GetPromptRequest {
 pub struct GetPromptRequestParams {
     ///Arguments to use for templating the prompt.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub arguments: ::std::option::Option<::std::collections::HashMap<::std::string::String, ::std::string::String>>,
+    pub arguments: ::std::option::Option<::std::collections::BTreeMap<::std::string::String, ::std::string::String>>,
     ///The name of the prompt or prompt template.
     pub name: ::std::string::String,
 }
@@ -4915,7 +4915,7 @@ pub struct ServerCapabilities {
     ///Experimental, non-standard capabilities that the server supports.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub experimental: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     ///Present if the server supports sending log messages to the client.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -5624,7 +5624,7 @@ pub struct Tool {
 pub struct ToolInputSchema {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub properties: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub required: ::std::vec::Vec<::std::string::String>,
@@ -5635,7 +5635,7 @@ impl ToolInputSchema {
     pub fn new(
         required: ::std::vec::Vec<::std::string::String>,
         properties: ::std::option::Option<
-            ::std::collections::HashMap<
+            ::std::collections::BTreeMap<
                 ::std::string::String,
                 ::serde_json::Map<::std::string::String, ::serde_json::Value>,
             >,

--- a/src/generated_schema/2025_03_26/mcp_schema.rs
+++ b/src/generated_schema/2025_03_26/mcp_schema.rs
@@ -498,7 +498,7 @@ pub struct ClientCapabilities {
     ///Experimental, non-standard capabilities that the client supports.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub experimental: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub roots: ::std::option::Option<ClientCapabilitiesRoots>,
@@ -1561,7 +1561,7 @@ impl GetPromptRequest {
 pub struct GetPromptRequestParams {
     ///Arguments to use for templating the prompt.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub arguments: ::std::option::Option<::std::collections::HashMap<::std::string::String, ::std::string::String>>,
+    pub arguments: ::std::option::Option<::std::collections::BTreeMap<::std::string::String, ::std::string::String>>,
     ///The name of the prompt or prompt template.
     pub name: ::std::string::String,
 }
@@ -4960,7 +4960,7 @@ pub struct ServerCapabilities {
     ///Experimental, non-standard capabilities that the server supports.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub experimental: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     ///Present if the server supports sending log messages to the client.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -5697,7 +5697,7 @@ pub struct ToolAnnotations {
 pub struct ToolInputSchema {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub properties: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub required: ::std::vec::Vec<::std::string::String>,
@@ -5708,7 +5708,7 @@ impl ToolInputSchema {
     pub fn new(
         required: ::std::vec::Vec<::std::string::String>,
         properties: ::std::option::Option<
-            ::std::collections::HashMap<
+            ::std::collections::BTreeMap<
                 ::std::string::String,
                 ::serde_json::Map<::std::string::String, ::serde_json::Value>,
             >,

--- a/src/generated_schema/2025_06_18/mcp_schema.rs
+++ b/src/generated_schema/2025_06_18/mcp_schema.rs
@@ -579,7 +579,7 @@ pub struct ClientCapabilities {
     ///Experimental, non-standard capabilities that the client supports.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub experimental: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub roots: ::std::option::Option<ClientCapabilitiesRoots>,
@@ -1056,7 +1056,7 @@ pub struct CompleteRequestParamsArgument {
 pub struct CompleteRequestParamsContext {
     ///Previously-resolved variables in a URI template or prompt.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub arguments: ::std::option::Option<::std::collections::HashMap<::std::string::String, ::std::string::String>>,
+    pub arguments: ::std::option::Option<::std::collections::BTreeMap<::std::string::String, ::std::string::String>>,
 }
 ///CompleteRequestParamsRef
 ///
@@ -1738,7 +1738,7 @@ Only top-level properties are allowed, without nesting.*/
 /// </details>
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct ElicitRequestedSchema {
-    pub properties: ::std::collections::HashMap<::std::string::String, PrimitiveSchemaDefinition>,
+    pub properties: ::std::collections::BTreeMap<::std::string::String, PrimitiveSchemaDefinition>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub required: ::std::vec::Vec<::std::string::String>,
     #[serde(rename = "type", deserialize_with = "validate::elicit_requested_schema_type_")]
@@ -1746,7 +1746,7 @@ pub struct ElicitRequestedSchema {
 }
 impl ElicitRequestedSchema {
     pub fn new(
-        properties: ::std::collections::HashMap<::std::string::String, PrimitiveSchemaDefinition>,
+        properties: ::std::collections::BTreeMap<::std::string::String, PrimitiveSchemaDefinition>,
         required: ::std::vec::Vec<::std::string::String>,
     ) -> Self {
         Self {
@@ -1813,7 +1813,7 @@ pub struct ElicitResult {
     /**The submitted form data, only present when action is "accept".
     Contains values matching the requested schema.*/
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub content: ::std::option::Option<::std::collections::HashMap<::std::string::String, ElicitResultContentValue>>,
+    pub content: ::std::option::Option<::std::collections::BTreeMap<::std::string::String, ElicitResultContentValue>>,
     ///See [General fields: _meta](/specification/2025-06-18/basic/index#meta) for notes on _meta usage.
     #[serde(rename = "_meta", default, skip_serializing_if = "::std::option::Option::is_none")]
     pub meta: ::std::option::Option<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
@@ -2169,7 +2169,7 @@ impl GetPromptRequest {
 pub struct GetPromptRequestParams {
     ///Arguments to use for templating the prompt.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub arguments: ::std::option::Option<::std::collections::HashMap<::std::string::String, ::std::string::String>>,
+    pub arguments: ::std::option::Option<::std::collections::BTreeMap<::std::string::String, ::std::string::String>>,
     ///The name of the prompt or prompt template.
     pub name: ::std::string::String,
 }
@@ -5771,7 +5771,7 @@ pub struct ServerCapabilities {
     ///Experimental, non-standard capabilities that the server supports.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub experimental: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     ///Present if the server supports sending log messages to the client.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -6702,7 +6702,7 @@ pub struct ToolAnnotations {
 pub struct ToolInputSchema {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub properties: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub required: ::std::vec::Vec<::std::string::String>,
@@ -6713,7 +6713,7 @@ impl ToolInputSchema {
     pub fn new(
         required: ::std::vec::Vec<::std::string::String>,
         properties: ::std::option::Option<
-            ::std::collections::HashMap<
+            ::std::collections::BTreeMap<
                 ::std::string::String,
                 ::serde_json::Map<::std::string::String, ::serde_json::Value>,
             >,
@@ -6848,7 +6848,7 @@ the structuredContent field of a CallToolResult.*/
 pub struct ToolOutputSchema {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub properties: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub required: ::std::vec::Vec<::std::string::String>,
@@ -6859,7 +6859,7 @@ impl ToolOutputSchema {
     pub fn new(
         required: ::std::vec::Vec<::std::string::String>,
         properties: ::std::option::Option<
-            ::std::collections::HashMap<
+            ::std::collections::BTreeMap<
                 ::std::string::String,
                 ::serde_json::Map<::std::string::String, ::serde_json::Value>,
             >,

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -607,7 +607,7 @@ pub struct ClientCapabilities {
     ///Experimental, non-standard capabilities that the client supports.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub experimental: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub roots: ::std::option::Option<ClientCapabilitiesRoots>,
@@ -1101,7 +1101,7 @@ pub struct CompleteRequestParamsArgument {
 pub struct CompleteRequestParamsContext {
     ///Previously-resolved variables in a URI template or prompt.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub arguments: ::std::option::Option<::std::collections::HashMap<::std::string::String, ::std::string::String>>,
+    pub arguments: ::std::option::Option<::std::collections::BTreeMap<::std::string::String, ::std::string::String>>,
 }
 ///CompleteRequestParamsRef
 ///
@@ -1817,7 +1817,7 @@ Only top-level properties are allowed, without nesting.*/
 /// </details>
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct ElicitRequestedSchema {
-    pub properties: ::std::collections::HashMap<::std::string::String, PrimitiveSchemaDefinition>,
+    pub properties: ::std::collections::BTreeMap<::std::string::String, PrimitiveSchemaDefinition>,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub required: ::std::vec::Vec<::std::string::String>,
     #[serde(rename = "type", deserialize_with = "validate::elicit_requested_schema_type_")]
@@ -1825,7 +1825,7 @@ pub struct ElicitRequestedSchema {
 }
 impl ElicitRequestedSchema {
     pub fn new(
-        properties: ::std::collections::HashMap<::std::string::String, PrimitiveSchemaDefinition>,
+        properties: ::std::collections::BTreeMap<::std::string::String, PrimitiveSchemaDefinition>,
         required: ::std::vec::Vec<::std::string::String>,
     ) -> Self {
         Self {
@@ -1892,7 +1892,7 @@ pub struct ElicitResult {
     /**The submitted form data, only present when action is "accept".
     Contains values matching the requested schema.*/
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub content: ::std::option::Option<::std::collections::HashMap<::std::string::String, ElicitResultContentValue>>,
+    pub content: ::std::option::Option<::std::collections::BTreeMap<::std::string::String, ElicitResultContentValue>>,
     ///See [General fields: _meta](/specification/draft/basic/index#meta) for notes on _meta usage.
     #[serde(rename = "_meta", default, skip_serializing_if = "::std::option::Option::is_none")]
     pub meta: ::std::option::Option<::serde_json::Map<::std::string::String, ::serde_json::Value>>,
@@ -2272,7 +2272,7 @@ impl GetPromptRequest {
 pub struct GetPromptRequestParams {
     ///Arguments to use for templating the prompt.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub arguments: ::std::option::Option<::std::collections::HashMap<::std::string::String, ::std::string::String>>,
+    pub arguments: ::std::option::Option<::std::collections::BTreeMap<::std::string::String, ::std::string::String>>,
     ///The name of the prompt or prompt template.
     pub name: ::std::string::String,
 }
@@ -6320,7 +6320,7 @@ pub struct ServerCapabilities {
     ///Experimental, non-standard capabilities that the server supports.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub experimental: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     ///Present if the server supports sending log messages to the client.
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
@@ -7308,7 +7308,7 @@ pub struct ToolAnnotations {
 pub struct ToolInputSchema {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub properties: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub required: ::std::vec::Vec<::std::string::String>,
@@ -7319,7 +7319,7 @@ impl ToolInputSchema {
     pub fn new(
         required: ::std::vec::Vec<::std::string::String>,
         properties: ::std::option::Option<
-            ::std::collections::HashMap<
+            ::std::collections::BTreeMap<
                 ::std::string::String,
                 ::serde_json::Map<::std::string::String, ::serde_json::Value>,
             >,
@@ -7465,7 +7465,7 @@ the structuredContent field of a CallToolResult.*/
 pub struct ToolOutputSchema {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub properties: ::std::option::Option<
-        ::std::collections::HashMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
+        ::std::collections::BTreeMap<::std::string::String, ::serde_json::Map<::std::string::String, ::serde_json::Value>>,
     >,
     #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
     pub required: ::std::vec::Vec<::std::string::String>,
@@ -7476,7 +7476,7 @@ impl ToolOutputSchema {
     pub fn new(
         required: ::std::vec::Vec<::std::string::String>,
         properties: ::std::option::Option<
-            ::std::collections::HashMap<
+            ::std::collections::BTreeMap<
                 ::std::string::String,
                 ::serde_json::Map<::std::string::String, ::serde_json::Value>,
             >,

--- a/tests/serde_smoke_test.rs
+++ b/tests/serde_smoke_test.rs
@@ -15,7 +15,7 @@ mod test_deserialize {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
     use serde_json::{Map, Value};
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     /* ---------------------- TESTS ---------------------- */
 
@@ -209,7 +209,7 @@ mod test_deserialize {
         let capabilities = ClientCapabilities {
             #[cfg(any(feature = "draft", feature = "2025_06_18"))]
             elicitation: Some(Map::new()),
-            experimental: Some(HashMap::new()),
+            experimental: Some(BTreeMap::new()),
             roots: Some(ClientCapabilitiesRoots::default()),
             sampling: Some(Map::new()),
         };
@@ -358,7 +358,7 @@ mod test_deserialize {
     fn test_elicit_request() {
         let params = ElicitRequestParams {
             message: "test".to_string(),
-            requested_schema: ElicitRequestedSchema::new(HashMap::new(), vec![]),
+            requested_schema: ElicitRequestedSchema::new(BTreeMap::new(), vec![]),
         };
 
         let req = ElicitRequest::new(


### PR DESCRIPTION
### 📌 Summary
Solves the problem of having non-deterministic tool definitions, the order changes around when getting large.

### ✨ Changes Made
Replaced all `HashMaps` with `BTreeMaps`


### 🛠️ Testing Steps
`cargo test` sufficient, I assume.

### 💡 Additional Notes

I did not dig too deep into how the code in this repo is generated and whether there's a better place to apply these changes. I am currently happily using my forked branch.

This PR is aimed at the latest release version, not main.