### PR TITLE
fix: incorrect NotificationFromServer method name mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cpufeatures"
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "json5"
@@ -75,32 +75,31 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "pest"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
- "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -108,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -121,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.1"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
@@ -131,18 +130,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -157,25 +156,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
+name = "serde"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -184,14 +187,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -207,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -217,30 +221,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "ucd-trie"
@@ -250,12 +234,18 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/src/generated_schema/2025_11_25/schema_utils.rs
+++ b/src/generated_schema/2025_11_25/schema_utils.rs
@@ -2766,15 +2766,13 @@ impl ClientCapabilities {
                     return Err(create_error("sampling task", request_method));
                 }
             }
-            ServerJsonrpcRequest::ListRootsRequest(_) => {
-                if self.roots.is_none() {
-                    return Err(create_error("roots capability", request_method));
-                }
+            ServerJsonrpcRequest::ListRootsRequest(_) if self.roots.is_none() => {
+                return Err(create_error("roots capability", request_method));
             }
-            ServerJsonrpcRequest::GetTaskRequest(_) | ServerJsonrpcRequest::GetTaskPayloadRequest(_) => {
-                if self.tasks.is_none() {
-                    return Err(create_error("Task", request_method));
-                }
+            ServerJsonrpcRequest::GetTaskRequest(_) | ServerJsonrpcRequest::GetTaskPayloadRequest(_)
+                if self.tasks.is_none() =>
+            {
+                return Err(create_error("Task", request_method));
             }
             ServerJsonrpcRequest::CancelTaskRequest(_) => {
                 if let Some(tasks) = self.tasks.as_ref() {

--- a/src/generated_schema/2025_11_25/schema_utils.rs
+++ b/src/generated_schema/2025_11_25/schema_utils.rs
@@ -317,7 +317,7 @@ impl RpcMessage for ClientMessage {
         }
     }
 
-     fn method(&self) -> Option<&str> {
+    fn method(&self) -> Option<&str> {
         match self {
             ClientMessage::Request(client_jsonrpc_request) => Some(client_jsonrpc_request.method()),
             ClientMessage::Notification(client_jsonrpc_notification) => Some(client_jsonrpc_notification.method()),
@@ -1505,14 +1505,18 @@ impl NotificationFromServer {
     pub fn method(&self) -> &str {
         match self {
             NotificationFromServer::CancelledNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::ProgressNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::ResourceListChangedNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::ResourceUpdatedNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::PromptListChangedNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::ToolListChangedNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::TaskStatusNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::LoggingMessageNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::ElicitationCompleteNotification(_params) => CancelledNotification::method_value(),
+            NotificationFromServer::ProgressNotification(_params) => ProgressNotification::method_value(),
+            NotificationFromServer::ResourceListChangedNotification(_params) => {
+                ResourceListChangedNotification::method_value()
+            }
+            NotificationFromServer::ResourceUpdatedNotification(_params) => ResourceUpdatedNotification::method_value(),
+            NotificationFromServer::PromptListChangedNotification(_params) => PromptListChangedNotification::method_value(),
+            NotificationFromServer::ToolListChangedNotification(_params) => ToolListChangedNotification::method_value(),
+            NotificationFromServer::TaskStatusNotification(_params) => TaskStatusNotification::method_value(),
+            NotificationFromServer::LoggingMessageNotification(_params) => LoggingMessageNotification::method_value(),
+            NotificationFromServer::ElicitationCompleteNotification(_params) => {
+                ElicitationCompleteNotification::method_value()
+            }
             NotificationFromServer::CustomNotification(params) => params.method.as_str(),
         }
     }

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -318,7 +318,7 @@ impl RpcMessage for ClientMessage {
         }
     }
 
-     fn method(&self) -> Option<&str> {
+    fn method(&self) -> Option<&str> {
         match self {
             ClientMessage::Request(client_jsonrpc_request) => Some(client_jsonrpc_request.method()),
             ClientMessage::Notification(client_jsonrpc_notification) => Some(client_jsonrpc_notification.method()),
@@ -1506,14 +1506,18 @@ impl NotificationFromServer {
     pub fn method(&self) -> &str {
         match self {
             NotificationFromServer::CancelledNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::ProgressNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::ResourceListChangedNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::ResourceUpdatedNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::PromptListChangedNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::ToolListChangedNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::TaskStatusNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::LoggingMessageNotification(_params) => CancelledNotification::method_value(),
-            NotificationFromServer::ElicitationCompleteNotification(_params) => CancelledNotification::method_value(),
+            NotificationFromServer::ProgressNotification(_params) => ProgressNotification::method_value(),
+            NotificationFromServer::ResourceListChangedNotification(_params) => {
+                ResourceListChangedNotification::method_value()
+            }
+            NotificationFromServer::ResourceUpdatedNotification(_params) => ResourceUpdatedNotification::method_value(),
+            NotificationFromServer::PromptListChangedNotification(_params) => PromptListChangedNotification::method_value(),
+            NotificationFromServer::ToolListChangedNotification(_params) => ToolListChangedNotification::method_value(),
+            NotificationFromServer::TaskStatusNotification(_params) => TaskStatusNotification::method_value(),
+            NotificationFromServer::LoggingMessageNotification(_params) => LoggingMessageNotification::method_value(),
+            NotificationFromServer::ElicitationCompleteNotification(_params) => {
+                ElicitationCompleteNotification::method_value()
+            }
             NotificationFromServer::CustomNotification(params) => params.method.as_str(),
         }
     }

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -2767,15 +2767,13 @@ impl ClientCapabilities {
                     return Err(create_error("sampling task", request_method));
                 }
             }
-            ServerJsonrpcRequest::ListRootsRequest(_) => {
-                if self.roots.is_none() {
-                    return Err(create_error("roots capability", request_method));
-                }
+            ServerJsonrpcRequest::ListRootsRequest(_) if self.roots.is_none() => {
+                return Err(create_error("roots capability", request_method));
             }
-            ServerJsonrpcRequest::GetTaskRequest(_) | ServerJsonrpcRequest::GetTaskPayloadRequest(_) => {
-                if self.tasks.is_none() {
-                    return Err(create_error("Task", request_method));
-                }
+            ServerJsonrpcRequest::GetTaskRequest(_) | ServerJsonrpcRequest::GetTaskPayloadRequest(_)
+                if self.tasks.is_none() =>
+            {
+                return Err(create_error("Task", request_method));
             }
             ServerJsonrpcRequest::CancelTaskRequest(_) => {
                 if let Some(tasks) = self.tasks.as_ref() {


### PR DESCRIPTION
### 📌 Summary
Fixed incorrect method name mappings in `NotificationFromServer::method()` that caused all notification types (except `CancelledNotification`) to incorrectly return `CancelledNotification`'s method value.


### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

- #110 


### ✨ Changes Made

- Corrected `NotificationFromServer::method()` in both `draft/schema_utils.rs` and `2025_11_25/schema_utils.rs`

### 🛠️ Testing Steps
Run the existing test suite to verify the fix doesn't break any functionality.
```
./scripts/run_test.sh                                                                                                  │
./scripts/run_clippy.sh 
```

### 💡 Additional Notes
Cargo.lock was also updated as part of `cargo update` or similar dependency refresh.
