### PR TITLE
fix: change NumberSchema numeric fields from i64 to f64

### DIFF
--- a/src/generated_schema/2025_11_25/mcp_schema.rs
+++ b/src/generated_schema/2025_11_25/mcp_schema.rs
@@ -5609,13 +5609,13 @@ pub struct NotificationParams {
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct NumberSchema {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub default: ::std::option::Option<i64>,
+    pub default: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub maximum: ::std::option::Option<i64>,
+    pub maximum: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub minimum: ::std::option::Option<i64>,
+    pub minimum: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]

--- a/src/generated_schema/2025_11_25/schema_utils.rs
+++ b/src/generated_schema/2025_11_25/schema_utils.rs
@@ -2417,9 +2417,9 @@ impl TryFrom<&serde_json::Map<String, Value>> for PrimitiveSchemaDefinition {
                 ))
             }
             "number" | "integer" => {
-                let maximum = value.get("maximum").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
-                let minimum = value.get("minimum").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
-                let default = value.get("default").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
+                let maximum = value.get("maximum").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
+                let minimum = value.get("minimum").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
+                let default = value.get("default").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
 
                 PrimitiveSchemaDefinition::NumberSchema(NumberSchema {
                     default,

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6359,13 +6359,13 @@ pub struct NotificationParams {
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct NumberSchema {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub default: ::std::option::Option<i64>,
+    pub default: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub maximum: ::std::option::Option<i64>,
+    pub maximum: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub minimum: ::std::option::Option<i64>,
+    pub minimum: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -2418,9 +2418,9 @@ impl TryFrom<&serde_json::Map<String, Value>> for PrimitiveSchemaDefinition {
                 ))
             }
             "number" | "integer" => {
-                let maximum = value.get("maximum").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
-                let minimum = value.get("minimum").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
-                let default = value.get("default").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
+                let maximum = value.get("maximum").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
+                let minimum = value.get("minimum").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
+                let default = value.get("default").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
 
                 PrimitiveSchemaDefinition::NumberSchema(NumberSchema {
                     default,


### PR DESCRIPTION
### 📌 Summary
<!-- Provide a concise description of your changes. What problem does this PR solve? -->

Change `NumberSchema` numeric fields (`default`, `maximum`, `minimum`) from `i64` to `f64` to correctly represent JSON number values, which can include floating-point numbers.



### 🔍 Related Issues
<!-- Link related issues using keywords like "Fixes #123" or "Closes #456" -->

The `NumberSchema` struct (and the corresponding `schema_utils` deserialization logic) used `i64` for `default`, `maximum`, and `minimum` fields. Per the JSON Schema specification, the `number` type includes floating-point values, so these fields should be `f64`, not `i64`. Using `i64` would cause silent truncation or deserialization failures when non-integer values are encountered.


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

- Changed `NumberSchema.{default, maximum, minimum}` from `Option<i64>` to `Option<f64>` in `src/generated_schema/2025_11_25/mcp_schema.rs`
- Changed `NumberSchema.{default, maximum, minimum}` from `Option<i64>` to `Option<f64>` in `src/generated_schema/draft/mcp_schema.rs`
- Updated schema utility parsing from `as_i64()` to `as_f64()` in both `src/generated_schema/2025_11_25/schema_utils.rs` and `src/generated_schema/draft/schema_utils.rs`


### 💡 Additional Notes
- Potentially breaking: any code that destructures or constructs `NumberSchema` with integer literals will need type annotations or `.into()` conversions.
