### PR TITLE
feat: add `ContentBlock` embedded resource helpers and fix `NumberSchema` field types

### DIFF
--- a/src/generated_schema/2025_11_25/mcp_schema.rs
+++ b/src/generated_schema/2025_11_25/mcp_schema.rs
@@ -5609,13 +5609,13 @@ pub struct NotificationParams {
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct NumberSchema {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub default: ::std::option::Option<i64>,
+    pub default: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub maximum: ::std::option::Option<i64>,
+    pub maximum: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub minimum: ::std::option::Option<i64>,
+    pub minimum: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]

--- a/src/generated_schema/2025_11_25/schema_utils.rs
+++ b/src/generated_schema/2025_11_25/schema_utils.rs
@@ -2417,9 +2417,9 @@ impl TryFrom<&serde_json::Map<String, Value>> for PrimitiveSchemaDefinition {
                 ))
             }
             "number" | "integer" => {
-                let maximum = value.get("maximum").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
-                let minimum = value.get("minimum").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
-                let default = value.get("default").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
+                let maximum = value.get("maximum").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
+                let minimum = value.get("minimum").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
+                let default = value.get("default").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
 
                 PrimitiveSchemaDefinition::NumberSchema(NumberSchema {
                     default,

--- a/src/generated_schema/2025_11_25/schema_utils.rs
+++ b/src/generated_schema/2025_11_25/schema_utils.rs
@@ -4237,6 +4237,42 @@ impl ContentBlock {
             ))),
         }
     }
+
+    /// Build a `ContentBlock::EmbeddedResource` carrying a text payload
+    /// (e.g. JSON, plain text, source code).
+    ///
+    /// Shortcut for:
+    /// ```ignore
+    /// EmbeddedResource::new(
+    ///     EmbeddedResourceResource::TextResourceContents(
+    ///         TextResourceContents::new(text, uri).with_mime_type(mime_type),
+    ///     ),
+    ///     None, None,
+    /// ).into()
+    /// ```
+    pub fn embedded_text_resource<U, M, T>(uri: U, mime_type: M, text: T) -> Self
+    where
+        U: Into<String>,
+        M: Into<String>,
+        T: Into<String>,
+    {
+        let trc = TextResourceContents::new(text.into(), uri.into()).with_mime_type(mime_type.into());
+        EmbeddedResource::new(EmbeddedResourceResource::TextResourceContents(trc), None, None).into()
+    }
+
+    /// Build a `ContentBlock::EmbeddedResource` carrying a base64-encoded
+    /// binary payload (images, audio, arbitrary file blobs).
+    ///
+    /// `base64_data` must already be base64-encoded.
+    pub fn embedded_blob_resource<U, M, D>(uri: U, mime_type: M, base64_data: D) -> Self
+    where
+        U: Into<String>,
+        M: Into<String>,
+        D: Into<String>,
+    {
+        let brc = BlobResourceContents::new(base64_data.into(), uri.into()).with_mime_type(mime_type.into());
+        EmbeddedResource::new(EmbeddedResourceResource::BlobResourceContents(brc), None, None).into()
+    }
 }
 impl CallToolResult {
     pub fn text_content(content: Vec<TextContent>) -> Self {

--- a/src/generated_schema/draft/mcp_schema.rs
+++ b/src/generated_schema/draft/mcp_schema.rs
@@ -6359,13 +6359,13 @@ pub struct NotificationParams {
 #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
 pub struct NumberSchema {
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub default: ::std::option::Option<i64>,
+    pub default: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub description: ::std::option::Option<::std::string::String>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub maximum: ::std::option::Option<i64>,
+    pub maximum: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
-    pub minimum: ::std::option::Option<i64>,
+    pub minimum: ::std::option::Option<f64>,
     #[serde(default, skip_serializing_if = "::std::option::Option::is_none")]
     pub title: ::std::option::Option<::std::string::String>,
     #[serde(rename = "type")]

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -2418,9 +2418,9 @@ impl TryFrom<&serde_json::Map<String, Value>> for PrimitiveSchemaDefinition {
                 ))
             }
             "number" | "integer" => {
-                let maximum = value.get("maximum").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
-                let minimum = value.get("minimum").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
-                let default = value.get("default").and_then(|v| v.as_number().and_then(|n| n.as_i64()));
+                let maximum = value.get("maximum").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
+                let minimum = value.get("minimum").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
+                let default = value.get("default").and_then(|v| v.as_number().and_then(|n| n.as_f64()));
 
                 PrimitiveSchemaDefinition::NumberSchema(NumberSchema {
                     default,

--- a/src/generated_schema/draft/schema_utils.rs
+++ b/src/generated_schema/draft/schema_utils.rs
@@ -4218,6 +4218,42 @@ impl ContentBlock {
             ))),
         }
     }
+
+    /// Build a `ContentBlock::EmbeddedResource` carrying a text payload
+    /// (e.g. JSON, plain text, source code).
+    ///
+    /// Shortcut for:
+    /// ```ignore
+    /// EmbeddedResource::new(
+    ///     EmbeddedResourceResource::TextResourceContents(
+    ///         TextResourceContents::new(text, uri).with_mime_type(mime_type),
+    ///     ),
+    ///     None, None,
+    /// ).into()
+    /// ```
+    pub fn embedded_text_resource<U, M, T>(uri: U, mime_type: M, text: T) -> Self
+    where
+        U: Into<String>,
+        M: Into<String>,
+        T: Into<String>,
+    {
+        let trc = TextResourceContents::new(text.into(), uri.into()).with_mime_type(mime_type.into());
+        EmbeddedResource::new(EmbeddedResourceResource::TextResourceContents(trc), None, None).into()
+    }
+
+    /// Build a `ContentBlock::EmbeddedResource` carrying a base64-encoded
+    /// binary payload (images, audio, arbitrary file blobs).
+    ///
+    /// `base64_data` must already be base64-encoded.
+    pub fn embedded_blob_resource<U, M, D>(uri: U, mime_type: M, base64_data: D) -> Self
+    where
+        U: Into<String>,
+        M: Into<String>,
+        D: Into<String>,
+    {
+        let brc = BlobResourceContents::new(base64_data.into(), uri.into()).with_mime_type(mime_type.into());
+        EmbeddedResource::new(EmbeddedResourceResource::BlobResourceContents(brc), None, None).into()
+    }
 }
 impl CallToolResult {
     pub fn text_content(content: Vec<TextContent>) -> Self {


### PR DESCRIPTION
### 📌 Summary
<!-- Provide a concise description of your changes. What problem does this PR solve? -->

Add ContentBlock embedded resource helpers 


### ✨ Changes Made
<!-- List the key changes introduced in this PR -->

**`ContentBlock` embedded resource helpers** (`schema_utils.rs` in both versions)
- `ContentBlock::embedded_text_resource(uri, mime_type, text)` — convenience constructor for text-based embedded resources (JSON, plain text, source code, etc.)
- `ContentBlock::embedded_blob_resource(uri, mime_type, base64_data)` — convenience constructor for binary embedded resources (images, audio, arbitrary blobs) from base64-encoded data.

Both helpers mirror the existing `text_content` / `image_content` pattern on `CallToolResult`.
